### PR TITLE
Crash at exit fixes

### DIFF
--- a/MinHook/build/VC12/libMinHook.vcxproj
+++ b/MinHook/build/VC12/libMinHook.vcxproj
@@ -88,6 +88,7 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FunctionLevelLinking>true</FunctionLevelLinking>
+      <ProgramDataBaseFileName />
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -105,6 +106,7 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FunctionLevelLinking>true</FunctionLevelLinking>
+      <ProgramDataBaseFileName />
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -117,11 +119,12 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>None</DebugInformationFormat>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <CompileAs>CompileAsC</CompileAs>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <ProgramDataBaseFileName />
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -140,6 +143,7 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <ProgramDataBaseFileName />
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>

--- a/x360ce/Common/COMDeleter.h
+++ b/x360ce/Common/COMDeleter.h
@@ -6,6 +6,11 @@ public:
 	template <typename T>
 	void operator()(T* ptr)
 	{
-		ptr->Release();
+		if (ptr)
+		{
+			PrintLog("Releasing COM Object %p", ptr);
+			ptr->Release();
+			ptr = nullptr;
+		}
 	}
 };

--- a/x360ce/x360ce/ControllerManager.h
+++ b/x360ce/x360ce/ControllerManager.h
@@ -30,6 +30,9 @@ public:
 
 		m_config.ReadConfig();
 
+		HMODULE hDinput8;
+		GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN, (LPCSTR) &DirectInput8Create, &hDinput8);
+
 		bool bHookDI = InputHookManager::Get().GetInputHook().GetState(InputHook::HOOK_DI);
 		if (bHookDI) InputHookManager::Get().GetInputHook().DisableHook(InputHook::HOOK_DI);
 		HRESULT ret = DirectInput8Create(CurrentModule(), DIRECTINPUT_VERSION, IID_IDirectInput8A, (void**)&m_pDirectInput, NULL);

--- a/x360ce/x360ce/ForceFeedback.cpp
+++ b/x360ce/x360ce/ForceFeedback.cpp
@@ -39,14 +39,10 @@ void ForceFeedback::Shutdown()
 {
 	if ((m_pController->m_useforce) && (!m_pController->m_forcespassthrough) && (m_pController->m_pDevice))
 	{
-		m_pController->m_pDevice->SendForceFeedbackCommand(DISFFC_SETACTUATORSOFF);
-		m_pController->m_pDevice->SendForceFeedbackCommand(DISFFC_STOPALL); // DISFFC_RESET or DISFFC_STOPALL
-		m_pController->m_pDevice->SendForceFeedbackCommand(DISFFC_RESET); // DISFFC_RESET or DISFFC_STOPALL
-	}
-
-	for (auto it = m_effects.begin(); it != m_effects.end(); ++it)
-	{
-		(*it)->Release();
+		/* CRASH CRASH CRASH */
+		//m_pController->m_pDevice->SendForceFeedbackCommand(DISFFC_SETACTUATORSOFF);
+		//m_pController->m_pDevice->SendForceFeedbackCommand(DISFFC_STOPALL); // DISFFC_RESET or DISFFC_STOPALL
+		//m_pController->m_pDevice->SendForceFeedbackCommand(DISFFC_RESET); // DISFFC_RESET or DISFFC_STOPALL
 	}
 }
 
@@ -69,7 +65,7 @@ BOOL CALLBACK ForceFeedback::EnumEffectsCallback(LPCDIEFFECTINFO di, LPVOID pvRe
 	caps.PeriodicForce = DIEFT_GETTYPE(di->dwEffType) == DIEFT_PERIODIC;
 	caps.RampForce = DIEFT_GETTYPE(di->dwEffType) == DIEFT_RAMPFORCE;
 
-	ffb->SetCaps(caps);
+	ffb->m_Caps = caps;
 	PrintLog("ForceFeedback effect '%s'. IsConstant = %d, IsPeriodic = %d", di->tszName, caps.ConstantForce, caps.PeriodicForce);
 	return DIENUM_CONTINUE;
 }
@@ -298,7 +294,7 @@ bool ForceFeedback::SetDeviceForces(XINPUT_VIBRATION* pVibration, u8 forceType)
 		else
 		{
 			PrintLog("[PAD%d] CreateEffect succeded effectIndex %d", m_pController->m_user + 1, 1);
-			m_effects.push_back(effectX);
+			m_effects.emplace_back(effectX);
 		}
 		if (m_Axes > 1)
 		{
@@ -313,7 +309,7 @@ bool ForceFeedback::SetDeviceForces(XINPUT_VIBRATION* pVibration, u8 forceType)
 			else
 			{
 				PrintLog("[PAD%d] CreateEffect succeded effectIndex %d", m_pController->m_user + 1, 1);
-				m_effects.push_back(effectY);
+				m_effects.emplace_back(effectY);
 			}
 		}
 	}

--- a/x360ce/x360ce/ForceFeedback.h
+++ b/x360ce/x360ce/ForceFeedback.h
@@ -23,16 +23,11 @@ private:
 	static BOOL CALLBACK EnumFFAxesCallback(const DIDEVICEOBJECTINSTANCE* pdidoi, VOID* pContext);
 	static BOOL CALLBACK EnumEffectsCallback(LPCDIEFFECTINFO di, LPVOID pvRef);
 
-	void SetCaps(const ForceFeedbackCaps& caps)
-	{
-		m_Caps = caps;
-	}
-
 	void StartEffects(DIEFFECT* diEffect, LPDIRECTINPUTEFFECT* effect, BOOL restartEffect);
 	bool SetDeviceForces(XINPUT_VIBRATION* pVibration, u8 forceType);
 
 	Controller* m_pController;
-	std::vector<LPDIRECTINPUTEFFECT> m_effects;
+	std::vector<std::unique_ptr<IDirectInputEffect, COMDeleter>> m_effects;
 	u8 m_Axes;
 	ForceFeedbackCaps m_Caps;
 };

--- a/x360ce/x360ce/dllmain.cpp
+++ b/x360ce/x360ce/dllmain.cpp
@@ -8,7 +8,7 @@
 #include "ControllerManager.h"
 #include "InputHookManager.h"
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && defined(VLD)
 #include <vld.h> 
 #endif
 


### PR DESCRIPTION
Crash caused by SendForceFeedbackCommand.

Please do not marge this yet, currently this may cause memory leak of FFB effects.
