### PR TITLE
CompatibilityList - add 5 games including Spelunky

### DIFF
--- a/Wiki/CompatibilityList.md
+++ b/Wiki/CompatibilityList.md
@@ -169,6 +169,7 @@ This is the new system utilised by r574+
   1. NBA 2k14
   1. NBA 2k15
   1. Need For Speed Most Wanted 2012
+  1. Nuclear Throne
   1. Outlast (32bit and 64bit executables, defaults to 64bit on 64bit OS)
   1. Penny Arcade's On the Rain-Slick Precipice of Darkness 3
   1. Penny Arcade's On the Rain-Slick Precipice of Darkness 4

--- a/Wiki/CompatibilityList.md
+++ b/Wiki/CompatibilityList.md
@@ -197,6 +197,7 @@ This is the new system utilised by r574+
   1. Sonic Generations
   1. Sonic the Hedgehog 4 EP 1
   1. Spelunky
+  1. Starwhal
   1. Street Fighter IV
   1. Street Fighter x Tekken
   1. Sudeki (Steam) (uses xinput1_2.dll)

--- a/Wiki/CompatibilityList.md
+++ b/Wiki/CompatibilityList.md
@@ -95,6 +95,7 @@ This is the new system utilised by r574+
   1. Batman Arkham City (uses xinput9_1_0.dll)
   1. Batman Arkham Origins
   1. Battlefield 3 (uses xinput9_1_0.dll)
+  1. Before the Echo
   1. BioHazard 6 (needs dinput8.dll)
   1. BioShock Infinite
   1. Blade Kitten

--- a/Wiki/CompatibilityList.md
+++ b/Wiki/CompatibilityList.md
@@ -210,6 +210,7 @@ This is the new system utilised by r574+
   1. Tiny Brains
   1. Titanfall (32bit and 64bit executables, defaults to 64bit on 64bit OS)
   1. Tomb Raider(2013) (uses xinput9_1_0.dll)
+  1. TowerFall Ascension
   1. Trine (If using Type 2 rumble, increase motor duration to 500)
   1. Trine 2 (If using Type 2 rumble, increase motor duration to 500)
   1. Trine 3 (If using Type 2 rumble, increase motor duration to 500)

--- a/Wiki/CompatibilityList.md
+++ b/Wiki/CompatibilityList.md
@@ -196,6 +196,7 @@ This is the new system utilised by r574+
   1. Sonic & All-Stars Racing Transformed
   1. Sonic Generations
   1. Sonic the Hedgehog 4 EP 1
+  1. Spelunky
   1. Street Fighter IV
   1. Street Fighter x Tekken
   1. Sudeki (Steam) (uses xinput1_2.dll)


### PR DESCRIPTION
Add the following games to `CompatibilityList.md`:
- Before the Echo
- Nuclear Throne
- Spelunky
- Starwhal
- TowerFall Ascension

All of them are added to the section "Hookmask Not Required".

Compatibility has been verified by me today. I used x360ce v3.2.9.81 (2015-10-04) and Steam versions of all the games.
