### PR TITLE
Update C++ Issue Helper

### DIFF
--- a/x360ce.App.Beta/Issues/CppX86RuntimeInstallIssue.cs
+++ b/x360ce.App.Beta/Issues/CppX86RuntimeInstallIssue.cs
@@ -1,44 +1,64 @@
 ﻿using JocysCom.ClassLibrary.Controls.IssuesControl;
+using Microsoft.Win32;
 using System;
 using System.Linq;
 
 namespace x360ce.App.Issues
 {
-	public class CppX86RuntimeInstallIssue : IssueItem
-	{
+    public class CppX86RuntimeInstallIssue : IssueItem
+    {
+        public CppX86RuntimeInstallIssue() : base()
+        {
+            Name = "Software";
+            FixName = "Download and Install";
+            MoreInfo = new Uri("https://learn.microsoft.com/cpp/windows/latest-supported-vc-redists");
+        }
 
-		public CppX86RuntimeInstallIssue() : base()
-		{
-			Name = "Software";
-			FixName = "Download and Install";
-			MoreInfo = new Uri("https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads");
-		}
+        static readonly Version MinVcRuntimeVersion = new Version(14, 0, 23026, 0);
 
-		// Use ignore case modifier.
-		string program1Rx = "(?i)(Visual C\\+\\+).*(2015|2017|2019).*(Redistributable).*(x86)";
-		string program1 = "Microsoft Visual C++ 2015-2019 Redistributable (x86)";
+        public override void CheckTask()
+        {
+            Version installedVersion = GetVcRuntimeVersionX86();
 
-		public override void CheckTask()
-		{
-			var installed = IssueHelper.IsInstalled(program1Rx, false);
-			if (!installed)
-			{
-				SetSeverity(
-					IssueSeverity.Critical, 1,
-					string.Format("Install " + program1)
-				);
-				return;
-			}
-			SetSeverity(IssueSeverity.None);
-		}
+            if (installedVersion == null || installedVersion < MinVcRuntimeVersion)
+            {
+                SetSeverity(
+                    IssueSeverity.Critical, 1,
+                    "Install or update Microsoft Visual C++ Redistributable (x86)"
+                );
+                return;
+            }
 
-		public override void FixTask()
-		{
-			// Microsoft Visual C++ 2015, 2017, 2019 Redistributable
-			var uri = new Uri("https://aka.ms/vs/16/release/vc_redist.x86.exe");
-			var localPath = System.IO.Path.Combine(x360ce.Engine.EngineHelper.AppDataPath, "Temp", uri.Segments.Last());
-			IssueHelper.DownloadAndInstall(uri, localPath, MoreInfo);
-		}
+            SetSeverity(IssueSeverity.None);
+        }
 
-	}
+        private static Version GetVcRuntimeVersionX86()
+        {
+            const string keyPath = @"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86";
+
+            using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+            using (var key = baseKey.OpenSubKey(keyPath))
+            {
+                if (key == null)
+                    return null;
+
+                if (Convert.ToInt32(key.GetValue("Installed", 0)) != 1)
+                    return null;
+
+                int major = Convert.ToInt32(key.GetValue("Major", 0));
+                int minor = Convert.ToInt32(key.GetValue("Minor", 0));
+                int bld   = Convert.ToInt32(key.GetValue("Bld",   0));
+                int rbld  = Convert.ToInt32(key.GetValue("RBld",  0));
+
+                return new Version(major, minor, bld, rbld);
+            }
+        }
+
+        public override void FixTask()
+        {
+            var uri = new Uri("https://aka.ms/vs/17/release/vc_redist.x86.exe");
+            var localPath = System.IO.Path.Combine(x360ce.Engine.EngineHelper.AppDataPath, "Temp", uri.Segments.Last());
+            IssueHelper.DownloadAndInstall(uri, localPath, MoreInfo);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1575 and #1572

Updates from Regex that can get outdated to checking version number, this should be able to last forever, newer versions are backwards compatible