### PR TITLE
Fix cross-thread crash in GetActiveControl when called from finalizer thread

### DIFF
--- a/x360ce.Engine/JocysCom/Controls/ControlsHelper.WPF.cs
+++ b/x360ce.Engine/JocysCom/Controls/ControlsHelper.WPF.cs
@@ -488,12 +488,12 @@ namespace JocysCom.ClassLibrary.Controls
 			var container = control as DependencyObject;
 			while (container != null)
 			{
-				FrameworkElement _nextControl = null;
+				FrameworkElement nextControl = null;
 				Invoke(() =>
 				{
-					_nextControl = System.Windows.Input.FocusManager.GetFocusedElement(control) as FrameworkElement;
+					nextControl = System.Windows.Input.FocusManager.GetFocusedElement(control) as FrameworkElement;
 				});
-				control = _nextControl;
+				control = nextControl;
 				if (control is null)
 					break;
 				Invoke(() =>

--- a/x360ce.Engine/JocysCom/Controls/ControlsHelper.WPF.cs
+++ b/x360ce.Engine/JocysCom/Controls/ControlsHelper.WPF.cs
@@ -488,7 +488,12 @@ namespace JocysCom.ClassLibrary.Controls
 			var container = control as DependencyObject;
 			while (container != null)
 			{
-				control = System.Windows.Input.FocusManager.GetFocusedElement(control) as FrameworkElement;
+				FrameworkElement _nextControl = null;
+				Invoke(() =>
+				{
+					_nextControl = System.Windows.Input.FocusManager.GetFocusedElement(control) as FrameworkElement;
+				});
+				control = _nextControl;
 				if (control is null)
 					break;
 				Invoke(() =>


### PR DESCRIPTION
## Summary

- `FocusManager.GetFocusedElement` internally calls `Dispatcher.VerifyAccess()` and must run on the UI thread
- In `GetActiveControl`, the other UI property accesses (`.Name`) were already wrapped in `Invoke(...)` — but the `GetFocusedElement` call in the `while` loop was not
- When an unobserved `Task` exception is garbage-collected, .NET fires `TaskScheduler.UnobservedTaskException` on the **GC finalizer thread**, which chains into `LogHelper.WriteException` → `ErrorsHelper.LogHelper_Current_WritingException` → `GetActiveControl`
- Calling `FocusManager.GetFocusedElement` from the finalizer thread threw `InvalidOperationException: The calling thread cannot access this object because a different thread owns it`, which was unhandled and killed the process

## Fix

Wrap the `GetFocusedElement` call in `Invoke(() => { ... })`, consistent with the `.Name` accesses directly above and below it in the same method.

## Reproduction

Run `x360ce.exe` — it crashes within seconds with:

```
Unhandled Exception: System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it.
   at System.Windows.Threading.Dispatcher.VerifyAccess()
   at System.Windows.Input.FocusManager.GetFocusedElement(...)
   at JocysCom.ClassLibrary.Controls.ControlsHelper.GetActiveControl(...)
   at x360ce.App.ErrorsHelper.LogHelper_Current_WritingException(...)
   at JocysCom.ClassLibrary.Runtime.LogHelper.WriteException(...)
   at System.Threading.Tasks.TaskExceptionHolder.Finalize()
```