### PR TITLE
FIX: 1609: Crash while refreshing devices when the device list changes

### DIFF
--- a/App.v4/Common/SettingsManager.cs
+++ b/App.v4/Common/SettingsManager.cs
@@ -201,7 +201,7 @@ namespace x360ce.App
 
 		public static UserDevice GetDevice(Guid instanceGuid)
 		{
-			return UserDevices.Items.FirstOrDefault(x =>
+			return UserDevices.ItemsToArraySyncronized().FirstOrDefault(x =>
 				x.InstanceGuid.Equals(instanceGuid));
 		}
 
@@ -220,7 +220,7 @@ namespace x360ce.App
 			var instances = settings
 				.Where(x => x.MapTo == (int)mapTo)
 				.Select(x => x.InstanceGuid).ToArray();
-			var devices = UserDevices.Items
+			var devices = UserDevices.ItemsToArraySyncronized()
 				.Where(x => instances.Contains(x.InstanceGuid))
 				.ToList();
 			// Return available devices.

--- a/App.v4/Common/TestDeviceHelper.cs
+++ b/App.v4/Common/TestDeviceHelper.cs
@@ -16,8 +16,11 @@ namespace x360ce.App
 		public static void EnableTestInstances()
 		{
 			// Add Test Devices (Make them appear connected online).
-			var items = SettingsManager.UserDevices
-				.Items.Where(x => x.ProductGuid == ProductGuid).ToArray();
+			// Snapshot under the collection lock. This runs on the device refresh thread
+			// while the interface thread can add or remove devices, and enumerating the
+			// live list throws "Collection was modified".
+			var items = SettingsManager.UserDevices.ItemsToArraySyncronized()
+				.Where(x => x.ProductGuid == ProductGuid).ToArray();
 			foreach (var item in items)
 			{
 				if (item.IsOnline)
@@ -60,11 +63,13 @@ namespace x360ce.App
 		{
 			var instanceName = "";
 			var productName = "Test Device";
+			// Snapshot once, for the same reason as above.
+			var existing = SettingsManager.UserDevices.ItemsToArraySyncronized();
 			for (int i = 1; ; i++)
 			{
 				instanceName = string.Format("{0} {1}", productName, i);
 				// If device with same name found then continue.
-				if (SettingsManager.UserDevices.Items.Any(x => x.InstanceName == instanceName))
+				if (existing.Any(x => x.InstanceName == instanceName))
 					continue;
 				break;
 			}

--- a/App.v4/Documents/ChangeLog.txt
+++ b/App.v4/Documents/ChangeLog.txt
@@ -1,4 +1,7 @@
-﻿v4.18.6.0 (2026-08-25)
+﻿v4.18.7.0 (2026-08-26)
+- Fixed: Crash while refreshing devices when the device list changed at the same time. Reading a device list on the refresh thread now takes a snapshot instead of walking the live collection.
+
+v4.18.6.0 (2026-08-25)
 - Fixed: Crash when a controller was unplugged and plugged back in. The hidden window that receives device messages was written to from the wrong thread.
 - Fixed: Interface stopped refreshing for the rest of the session if a redraw failed.
 - Changed: Device detection lists attached devices only, instead of every device ever installed. Devices that are unplugged still keep their settings and show as offline.

--- a/App.v4/Properties/AssemblyInfo.cs
+++ b/App.v4/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Resources;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.18.6.0")]
-[assembly: AssemblyFileVersion("4.18.6.0")]
+[assembly: AssemblyVersion("4.18.7.0")]
+[assembly: AssemblyFileVersion("4.18.7.0")]
 [assembly: AssemblyDelaySign(false)]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ Every signed build is published on the [Releases page](https://github.com/x360ce
 
 # Download v4.x
 
-Digitally Signed Application v4.18.6.0 and Virtual Gamepad Emulation Bus 1.16.112.0
+Digitally Signed Application v4.18.7.0 and Virtual Gamepad Emulation Bus 1.16.112.0
 
 Download `x360ce.zip` from the [latest v4 release](https://github.com/x360ce/x360ce/releases) - for All games
 
@@ -14,7 +14,7 @@ Note: version 4.x use Virtual Gamepad Emulation. Instructions can be found here:
 
 # Download v3.x
 
-Digitally Signed Application v3.2.9.82 and Libraries 3.4.1
+Digitally Signed Application v3.3.11.0 and Libraries 3.4.1
 
 Download `x360ce_x86.zip` from the [latest v3 release](https://github.com/x360ce/x360ce/releases#release-3.2.9.82) - for 32-bit games
 

--- a/README.MD
+++ b/README.MD
@@ -14,7 +14,7 @@ Note: version 4.x use Virtual Gamepad Emulation. Instructions can be found here:
 
 # Download v3.x
 
-Digitally Signed Application v3.3.11.0 and Libraries 3.4.1
+Digitally Signed Application v3.2.9.82 and Libraries 3.4.1
 
 Download `x360ce_x86.zip` from the [latest v3 release](https://github.com/x360ce/x360ce/releases#release-3.2.9.82) - for 32-bit games
 


### PR DESCRIPTION
Closes #1609

The refresh thread walked the live device collection while the interface thread was changing it, so enumeration threw `Collection was modified` and the update thread died. Support mail carries it twice from 4.18.6.0, once with the bound device grid named as the active control.

Four reads now go through `ItemsToArraySyncronized`, which takes the collection lock and returns a snapshot. `GetMappedDevices` was already fixed this way.

| Method | Note |
| --- | --- |
| `TestDeviceHelper.EnableTestInstances` | the crash being reported |
| `TestDeviceHelper.NewUserDevice` | same fault; also snapshots once instead of per loop iteration |
| `SettingsManager.GetDevice` | same fault |
| `SettingsManager.GetDevices` | same fault |

Version moves to 4.18.7.0, with the changelog entry and the v4 README line.

The v3 README line stays at the released 3.2.9.82. The README lists what can be downloaded, and v3 3.3.11.0 has not shipped yet.

[AI Coded]