### PR TITLE
FEAT: 1616: Mapping formulas, and the faults found while testing them

### DIFF
--- a/App.v3/Common/SettingManager.cs
+++ b/App.v3/Common/SettingManager.cs
@@ -379,6 +379,11 @@ namespace x360ce.App
 				Control control = SettingsMap[path];
 				string key = path.Split('\\')[1];
 				string v = ini2.GetValue(section, key);
+				// A tick box the file says nothing about keeps the value it was designed with.
+				// Without this an absent line reads as zero, so a setting meant to start on
+				// turns itself off the first time the program runs.
+				if (string.IsNullOrEmpty(v) && control is CheckBox)
+					continue;
 				ReadSettingTo(control, key, v);
 			}
 			loadCount++;

--- a/App.v3/Controls/OptionsControl.Designer.cs
+++ b/App.v3/Controls/OptionsControl.Designer.cs
@@ -371,6 +371,8 @@
 			// ExcludeVirtualDevicesCheckBox
 			// 
 			this.ExcludeVirtualDevicesCheckBox.AutoSize = true;
+			this.ExcludeVirtualDevicesCheckBox.Checked = true;
+			this.ExcludeVirtualDevicesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.ExcludeVirtualDevicesCheckBox.Location = new System.Drawing.Point(6, 42);
 			this.ExcludeVirtualDevicesCheckBox.Name = "ExcludeVirtualDevicesCheckBox";
 			this.ExcludeVirtualDevicesCheckBox.Size = new System.Drawing.Size(138, 17);

--- a/App.v3/MainForm.cs
+++ b/App.v3/MainForm.cs
@@ -535,6 +535,37 @@ namespace x360ce.App
 		public DirectInput Manager = new DirectInput();
 
 		/// <summary>
+		/// Vendor and product identifier of every XInput device attached to the machine.
+		/// </summary>
+		/// <remarks>
+		/// A device is an XInput device when its hardware identifier carries the IG_ marker,
+		/// which is how Microsoft documents telling XInput devices apart during DirectInput
+		/// enumeration. Both real controllers and the virtual pads a driver creates carry it.
+		/// </remarks>
+		static HashSet<uint> GetXInputIds()
+		{
+			var ids = new HashSet<uint>();
+			foreach (var info in DeviceDetector.GetDevices(null, DIGCF.DIGCF_ALLCLASSES | DIGCF.DIGCF_PRESENT))
+			{
+				if (string.IsNullOrEmpty(info.HardwareIds))
+					continue;
+				if (info.HardwareIds.IndexOf("IG_", StringComparison.OrdinalIgnoreCase) == -1)
+					continue;
+				ids.Add((info.ProductId << 16) | info.VendorId);
+			}
+			return ids;
+		}
+
+		/// <summary>
+		/// Vendor and product identifier a DirectInput device was built from.
+		/// </summary>
+		static uint GetVendorProductId(Guid productGuid)
+		{
+			// DirectInput places the same two numbers in the first four bytes of the identifier.
+			return BitConverter.ToUInt32(productGuid.ToByteArray(), 0);
+		}
+
+		/// <summary>
 		/// Get array[4] of direct input devices.
 		/// </summary>
 		DeviceInstance[] GetDevices()
@@ -557,6 +588,15 @@ namespace x360ce.App
 				foreach (var virtualDevice in virtualDevices)
 				{
 					devices.Remove(virtualDevice);
+				}
+				// The pads this program feeds are XInput devices, and XInput devices appear in
+				// DirectInput enumeration too. Reading one back would make the program take its
+				// own output as an input, add it as a new device, and repeat.
+				var xInputIds = GetXInputIds();
+				var xInputDevices = devices.Where(x => xInputIds.Contains(GetVendorProductId(x.ProductGuid))).ToArray();
+				foreach (var xInputDevice in xInputDevices)
+				{
+					devices.Remove(xInputDevice);
 				}
 			}
 			// Move gaming wheels to the top index position by default.

--- a/App.v3/Program.cs
+++ b/App.v3/Program.cs
@@ -29,6 +29,19 @@ namespace x360ce.App
 		[STAThread]
 		static void Main(string[] args)
 		{
+			// Set here rather than in a configuration file, because the program ships as one file
+			// and no configuration file travels with it. Left in app.config alone, none of these
+			// take effect for anyone who downloads it.
+			//
+			// Symbols are built into the program rather than shipped beside it, and the runtime
+			// ignores symbols in that form for a program built against a framework older than
+			// 4.7.2 unless it is asked. Without this a crash report names no file and no line.
+			AppContext.SetSwitch("Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces", false);
+			// Without these every control reaches a screen reader as an unnamed blank area.
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures", false);
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.2", false);
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.3", false);
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.4", false);
 			// First: Set working folder to the path of executable.
 			var fi = new FileInfo(Application.ExecutablePath);
 			Directory.SetCurrentDirectory(fi.Directory.FullName);

--- a/App.v3/app.config
+++ b/App.v3/app.config
@@ -12,13 +12,4 @@
       </setting>
     </x360ce.App.Properties.Settings>
   </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup>  <!--
-    Symbols are carried inside each binary rather than shipped beside it, so the program
-    stays one file. The runtime ignores symbols in that form for an application built
-    against a framework older than 4.7.2 unless asked, and without this a crash report
-    names no file and no line.
-  -->
-  <runtime>
-    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false"/>
-  </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/App.v4/Common/AdminCommand.cs
+++ b/App.v4/Common/AdminCommand.cs
@@ -7,8 +7,12 @@
     {
         InstallViGEmBus,
 		UninstallViGEmBus,
+		/// <summary>Remove the virtual bus and put it back, to recover one that has stopped working.</summary>
+		RepairViGEmBus,
         UninstallHidGuardian,
 		UninstallDevice,
+		/// <summary>Remove virtual pads left behind by runs that did not shut down cleanly.</summary>
+		RemoveLeftoverPads,
 #if DEBUG
 		/// <summary>Development builds only. Install is not offered in a release.</summary>
 		InstallHidGuardian,

--- a/App.v4/Common/DInput/DInputHelper.Step1.UpdateDevices.cs
+++ b/App.v4/Common/DInput/DInputHelper.Step1.UpdateDevices.cs
@@ -66,29 +66,17 @@ namespace x360ce.App.DInput
 			//Joystick    = new Guid("6f1d2b70-d5a0-11cf-bfc7-444553540000");
 			//SysMouse    = new Guid("6f1d2b60-d5a0-11cf-bfc7-444553540000");
 			//SysKeyboard = new Guid("6f1d2b61-d5a0-11cf-bfc7-444553540000");
+			var devInfosById = VirtualDriverInstaller.IndexById(devInfos);
 			for (int i = 0; i < addedDevices.Length; i++)
 			{
 				var device = addedDevices[i];
 				var ud = new UserDevice();
 				DeviceInfo hid;
 				RefreshDevice(manager, ud, device, devInfos, intInfos, out hid);
-				var isVirtual = false;
-				if (hid != null)
-				{
-					DeviceInfo p = hid;
-					do
-					{
-						p = devInfos.FirstOrDefault(x => x.DeviceId == p.ParentDeviceId);
-						// If ViGEm hardware found then...
-						if (p != null && VirtualDriverInstaller.ViGEmBusHardwareIds.Any(x => string.Compare(p.HardwareIds, x, true) == 0))
-						{
-							isVirtual = true;
-							break;
-						}
-
-					} while (p != null);
-				}
-				if (!isVirtual)
+				// Pads this program feeds are never taken back in as devices somebody could map, or it
+				// would read its own output as an input. The rule lives in one place so that the device
+				// list and the clean-up button can never disagree about what a leftover is.
+				if (!VirtualDriverInstaller.IsVirtualPad(hid, devInfosById))
 					insertDevices.Add(ud);
 			}
 			//if (insertDevices.Count > 0)
@@ -103,6 +91,12 @@ namespace x360ce.App.DInput
 				// Will refresh device and fill more values with new x360ce app if available.
 				RefreshDevice(manager, ud, device, devInfos, intInfos, out hid);
 			}
+			// Pads of ours written down before this was recognised. Every stored device is judged, not
+			// only those this pass enumerated, because the scan otherwise only ever marks a device
+			// offline and nothing once written down is ever taken out again.
+			var evictDevices = uds
+				.Where(x => VirtualDriverInstaller.IsVirtualPad(x, devInfosById))
+				.ToList();
 			if (Program.IsClosing)
 				return;
 			// Remove disconnected devices.
@@ -110,6 +104,25 @@ namespace x360ce.App.DInput
 			{
 				lock (SettingsManager.UserDevices.SyncRoot)
 					deleteDevices[i].IsOnline = false;
+			}
+			if (evictDevices.Count > 0)
+			{
+				// All of them removed in one step, on the thread that owns the list.
+				//
+				// Removing them one at a time from here does not work: the list works out a row's
+				// position now and hands that number to the window later, so the second removal names
+				// a row that the first has already moved. The window is then given a position that is
+				// no longer there and the removal fails, out of sight, on a thread nobody is watching.
+				//
+				// Sent rather than waited for, because waiting would put this loop behind whatever the
+				// window happens to be drawing, which is the thing this list was written to avoid.
+				var evicted = evictDevices.ToArray();
+				JocysCom.ClassLibrary.Controls.ControlsHelper.BeginInvoke(() =>
+				{
+					lock (SettingsManager.UserDevices.SyncRoot)
+						foreach (var ud in evicted)
+							SettingsManager.UserDevices.Items.Remove(ud);
+				});
 			}
 			for (int i = 0; i < insertDevices.Count; i++)
 			{

--- a/App.v4/Common/DInput/DInputHelper.Step3.UpdateXiStates.cs
+++ b/App.v4/Common/DInput/DInputHelper.Step3.UpdateXiStates.cs
@@ -118,6 +118,13 @@ namespace x360ce.App.DInput
 
 				foreach (var map in maps)
 				{
+					// A row driven by a formula names no single control, so it is worked out here and
+					// the rest of this loop, which is entirely about one control, is skipped.
+					if (map.Expression != null)
+					{
+						ApplyExpression(map, diState, ref gp);
+						continue;
+					}
 					// If not mapped then continue.
 					if (map.Index == 0)
 						continue;
@@ -362,6 +369,67 @@ namespace x360ce.App.DInput
 			var ev = StatesUpdated;
 			if (ev != null)
 				ev(this, new DInputEventArgs());
+		}
+
+		/// <summary>
+		/// Buffer for a formula's source values, reused rather than allocated on every poll.
+		/// </summary>
+		/// <remarks>
+		/// This runs for every mapped row of every controller, up to a thousand times a second. A
+		/// fresh array each time would hand the collector a steady stream of rubbish to clear up, and
+		/// a collection at the wrong moment is a stutter a player feels.
+		/// </remarks>
+		readonly float[] _expressionValues = new float[MapExpression.MaxReferences];
+
+		/// <summary>
+		/// Works out a formula against the controller as it is now, and puts the answer where the row
+		/// points.
+		/// </summary>
+		/// <remarks>
+		/// A formula answers in plain units: -1 to 1 for something that rests in the middle, 0 to 1
+		/// for something that rests at one end. Those are turned into what the destination expects
+		/// here, so the same formula can drive a stick, a trigger or a button and mean the same thing
+		/// in each.
+		///
+		/// A row driven by a formula ignores its dead zone, anti dead zone and sensitivity. Those
+		/// three shape a value on the way through, and so does the formula; applying both would give
+		/// a result neither of them describes. Switching a row over writes the settings out as part
+		/// of the formula, so nothing is lost by them no longer being read.
+		/// </remarks>
+		void ApplyExpression(Map map, CustomDiState diState, ref Gamepad gp)
+		{
+			// A stick is read from the middle, a trigger and a button from one end, exactly as the
+			// ordinary mapping path already does through GetThumbValue's own thumb flag.
+			var isThumb = map.Target == TargetType.LeftThumbX || map.Target == TargetType.LeftThumbY
+				|| map.Target == TargetType.RightThumbX || map.Target == TargetType.RightThumbY;
+			if (!MapExpressionUnits.TryFill(map.Expression, diState, _expressionValues, isThumb))
+				return;
+			var value = map.Expression.Evaluate(_expressionValues);
+			switch (map.Target)
+			{
+				case TargetType.LeftTrigger:
+					gp.LeftTrigger = MapExpressionUnits.ToTrigger(value);
+					break;
+				case TargetType.RightTrigger:
+					gp.RightTrigger = MapExpressionUnits.ToTrigger(value);
+					break;
+				case TargetType.LeftThumbX:
+					gp.LeftThumbX = MapExpressionUnits.ToThumb(value);
+					break;
+				case TargetType.LeftThumbY:
+					gp.LeftThumbY = MapExpressionUnits.ToThumb(value);
+					break;
+				case TargetType.RightThumbX:
+					gp.RightThumbX = MapExpressionUnits.ToThumb(value);
+					break;
+				case TargetType.RightThumbY:
+					gp.RightThumbY = MapExpressionUnits.ToThumb(value);
+					break;
+				case TargetType.Button:
+					if (MapExpressionUnits.IsPressed(value))
+						gp.Buttons |= map.ButtonFlag;
+					break;
+			}
 		}
 
 	}

--- a/App.v4/Common/DInput/DInputHelper.Step6.RetrieveXiStates.cs
+++ b/App.v4/Common/DInput/DInputHelper.Step6.RetrieveXiStates.cs
@@ -51,9 +51,62 @@ namespace x360ce.App.DInput
 					LiveXiStates[i] = state;
 				}
 			}
+			MatchPadsToPlaces();
 			var ev = StatesRetrieved;
 			if (ev != null)
 				ev(this, new DInputEventArgs(error));
+		}
+
+		/// <summary>
+		/// Which of the four XInput places holds each of this program's controllers.
+		/// </summary>
+		/// <remarks>
+		/// Index by pad, one to four. Minus one until it is known.
+		/// </remarks>
+		public int[] XiPlaceForPad = new int[] { -1, -1, -1, -1 };
+
+		/// <summary>
+		/// Works out which place Windows gave each controller this program created.
+		/// </summary>
+		/// <remarks>
+		/// This is not a choice the program gets to make. Windows offers four places for a controller
+		/// of this kind and decides for itself which one a new controller goes into; there is no way
+		/// to ask for a particular one. Measured on a computer with all four places empty, a
+		/// controller created by this program was put in the third.
+		///
+		/// Everything on screen used to assume controller one meant the first place. On that computer
+		/// it therefore read an empty place and showed a dead controller, while its own was sitting in
+		/// the third. Where somebody had a real Xbox controller plugged in, it read that instead, and
+		/// the picture moved when nobody was touching this program's controller at all.
+		///
+		/// So the place is found rather than assumed. Its own controllers are counted, the occupied
+		/// places are counted, and when those agree they are paired in order. That is exact whenever
+		/// every occupied place belongs to this program, which is the ordinary case. When something
+		/// else is plugged in as well the counts disagree, nothing is claimed, and the old assumption
+		/// stands rather than a guess being made.
+		/// </remarks>
+		void MatchPadsToPlaces()
+		{
+			var ours = new System.Collections.Generic.List<int>();
+			var client = Nefarius.ViGEm.Client.ViGEmClient.Current;
+			for (uint i = 1; i <= 4; i++)
+				if (client != null && client.IsControllerConnected(i))
+					ours.Add((int)i);
+			var occupied = new System.Collections.Generic.List<int>();
+			for (int place = 0; place < 4; place++)
+				if (LiveXiConnected[place])
+					occupied.Add(place);
+			// Only when the two agree is the pairing certain.
+			if (ours.Count == 0 || ours.Count != occupied.Count)
+			{
+				for (int i = 0; i < XiPlaceForPad.Length; i++)
+					XiPlaceForPad[i] = -1;
+				return;
+			}
+			for (int i = 0; i < XiPlaceForPad.Length; i++)
+				XiPlaceForPad[i] = -1;
+			for (int n = 0; n < ours.Count; n++)
+				XiPlaceForPad[ours[n] - 1] = occupied[n];
 		}
 
 	}

--- a/App.v4/Common/DInput/VirtualDriverInstaller.cs
+++ b/App.v4/Common/DInput/VirtualDriverInstaller.cs
@@ -2,6 +2,7 @@
 using JocysCom.ClassLibrary.Win32;
 using Microsoft.Win32;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -43,6 +44,246 @@ namespace x360ce.App.DInput
 
 		public static string[] ViGEmBusHardwareIds = { "Root\\ViGEmBus", "Nefarius\\ViGEmBus\\Gen1" };
 		public const string HidGuardianHardwareId = "Root\\HidGuardian";
+
+		#region Pads left behind
+
+		/// <summary>
+		/// Pads created by the virtual bus and never removed, from a run that ended without shutting
+		/// down cleanly.
+		/// </summary>
+		/// <remarks>
+		/// The existing device clean-up looks for devices that are offline, flagged with a problem, or
+		/// unknown. A pad left behind is none of those: it is present, healthy, and simply nobody's.
+		/// It matters because only four XInput places exist, so a handful of these fill every one and
+		/// the pad this program creates is pushed out of reach. What a player sees then is a controller
+		/// that moves on its own, because the state on show belongs to somebody else's leftover.
+		/// </remarks>
+		public static DeviceInfo[] GetLeftoverVirtualPads()
+		{
+			var all = DeviceDetector.GetDevices(null, DIGCF.DIGCF_ALLCLASSES | DIGCF.DIGCF_PRESENT);
+			var byId = IndexById(all);
+			return all
+				.Where(x => IsVirtualPad(x, byId))
+				// Not the ones this program is using right now. Offering to remove those would break
+				// the very thing somebody pressing the button is trying to repair.
+				.Where(x => !IsOneOfOurs(x, byId))
+				.OrderBy(x => x.DeviceId)
+				.ToArray();
+		}
+
+		/// <summary>
+		/// Whether a controller is one this program currently has plugged in.
+		/// </summary>
+		/// <remarks>
+		/// This program adds and removes controllers while it runs, so which ones are its own changes
+		/// from moment to moment. Anything decided once, at start-up, is wrong shortly afterwards: it
+		/// would miss one this program abandoned during the run, and would call one it created later
+		/// somebody else's.
+		///
+		/// The bus knows each controller by a number, and Windows puts that same number at the end of
+		/// the controller's name, as "&amp;01" for one and "&amp;02" for two. So the numbers of the
+		/// controllers this program is holding are asked for directly and matched against the name.
+		/// That is a clear reference to its own, rather than a guess from timing.
+		///
+		/// If the numbers cannot be read, nothing is claimed. Being wrong that way mentions a
+		/// controller that need not be mentioned; being wrong the other way offers to remove the one
+		/// in use.
+		/// </remarks>
+		public static bool IsOneOfOurs(DeviceInfo device, Dictionary<string, DeviceInfo> byId)
+		{
+			if (device == null || byId == null || string.IsNullOrEmpty(device.DeviceId))
+				return false;
+			var serials = OurSerials();
+			if (serials.Count == 0)
+				return false;
+			// A controller is not one device but a small family: the one the bus creates and the two
+			// beneath it that Windows adds. Only the top one carries the number, so the question is
+			// asked of the whole line of ancestors. Matching the name alone catches the top and misses
+			// the rest, and the ones missed are then reported as somebody's leftovers.
+			var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			var current = device;
+			while (current != null)
+			{
+				foreach (var serial in serials)
+					if (current.DeviceId != null &&
+						current.DeviceId.EndsWith("&" + serial.ToString("X2"), StringComparison.OrdinalIgnoreCase))
+						return true;
+				var parentId = current.ParentDeviceId;
+				if (string.IsNullOrEmpty(parentId) || !seen.Add(parentId))
+					return false;
+				DeviceInfo parent;
+				if (!byId.TryGetValue(parentId, out parent))
+					return false;
+				current = parent;
+			}
+			return false;
+		}
+
+		/// <summary>The bus numbers of the controllers this program is holding.</summary>
+		private static List<uint> OurSerials()
+		{
+			var serials = new List<uint>();
+			try
+			{
+				var client = Nefarius.ViGEm.Client.ViGEmClient.Current;
+				var targets = client == null ? null : client.Targets;
+				if (targets == null)
+					return serials;
+				for (uint i = 1; i <= targets.Length; i++)
+				{
+					var target = targets[i - 1];
+					if (target == null || !client.IsControllerConnected(i))
+						continue;
+					var serial = target.Serial;
+					if (serial != 0)
+						serials.Add(serial);
+				}
+			}
+			catch (Exception)
+			{
+				// Nothing claimed as ours, which is the safe way to be wrong.
+				return new List<uint>();
+			}
+			return serials;
+		}
+
+		/// <summary>Devices arranged for walking upwards, since a walk asks for a parent by name.</summary>
+		public static Dictionary<string, DeviceInfo> IndexById(IEnumerable<DeviceInfo> devices)
+		{
+			var byId = new Dictionary<string, DeviceInfo>(StringComparer.OrdinalIgnoreCase);
+			if (devices == null)
+				return byId;
+			foreach (var device in devices)
+				if (!string.IsNullOrEmpty(device.DeviceId))
+					byId[device.DeviceId] = device;
+			return byId;
+		}
+
+		/// <summary>
+		/// True when a device is one of the pads this program feeds, rather than something a player holds.
+		/// </summary>
+		/// <param name="device">Device to judge.</param>
+		/// <param name="byId">Every known device, from <see cref="IndexById"/>.</param>
+		/// <remarks>
+		/// A pad the bus is still holding descends from the bus, and walking up to it says so. A pad left
+		/// behind by a run that ended badly does not: the node its chain points at has gone, so the walk
+		/// arrives nowhere. That broken chain is itself the answer, because real hardware hangs off a real
+		/// bus and always reaches the top of the tree.
+		///
+		/// A broken chain only counts against a device that carries the XInput marker, which is what the
+		/// pads this program creates carry. Keeping the rule that narrow means a wheel or a stick with an
+		/// odd chain is still shown to its owner, and only the shape this program itself produces can be
+		/// judged missing.
+		/// </remarks>
+		public static bool IsVirtualPad(DeviceInfo device, Dictionary<string, DeviceInfo> byId)
+		{
+			if (device == null || byId == null)
+				return false;
+			// Read from the identifier as well as the hardware list. A pad created moments ago has an
+			// empty hardware list, and reading only that let three freshly leaked pads through while
+			// catching the older ones. The identifier carries the marker from the moment the device
+			// exists, so it is the dependable half.
+			var couldBeOurs = CarriesInputGroup(device.HardwareIds) || CarriesInputGroup(device.DeviceId);
+			// The bus is what makes the pads; it is not one of them. Answering otherwise would put the
+			// virtual driver itself on a list whose whole purpose is to be deleted, and taking the bus
+			// away removes the ability to emulate anything at all.
+			if (IsViGEmBus(device))
+				return false;
+			var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			var current = device;
+			while (true)
+			{
+				var parentId = current.ParentDeviceId;
+				// The top of the tree, reached through devices that all exist: real hardware.
+				if (string.IsNullOrEmpty(parentId))
+					return false;
+				DeviceInfo parent;
+				if (!byId.TryGetValue(parentId, out parent))
+					// The chain ends at a device that is not there. For one of our pads that means it
+					// was left behind; for anything else it means nothing, and it is left alone.
+					return couldBeOurs;
+				// Descended from the bus, so the bus made it, so it is ours.
+				if (IsViGEmBus(parent))
+					return true;
+				// A chain that returns somewhere it has already been is not a chain. Stop, rather than
+				// walk it forever and take the window down with it.
+				if (!seen.Add(parentId))
+					return couldBeOurs;
+				current = parent;
+			}
+		}
+
+		/// <summary>
+		/// The same judgement applied to a device already written down, from what was written down.
+		/// </summary>
+		/// <remarks>
+		/// A scan only looks at devices it happens to enumerate on that pass, so a leftover that is not
+		/// enumerated stays in the list for ever, marked offline but never taken out. This reads the
+		/// identifiers already stored against the device and puts them through the same rule, so a list
+		/// is cleaned up whether or not the device turned up again.
+		/// </remarks>
+		public static bool IsVirtualPad(x360ce.Engine.Data.UserDevice device, Dictionary<string, DeviceInfo> byId)
+		{
+			if (device == null)
+				return false;
+			return IsVirtualPad(Described(device.HidDeviceId, device.HidParentDeviceId, device.HidHardwareIds), byId)
+				|| IsVirtualPad(Described(device.DevDeviceId, device.DevParentDeviceId, device.DevHardwareIds), byId);
+		}
+
+		private static DeviceInfo Described(string deviceId, string parentId, string hardwareIds)
+		{
+			return string.IsNullOrEmpty(deviceId)
+				? null
+				: new DeviceInfo { DeviceId = deviceId, ParentDeviceId = parentId, HardwareIds = hardwareIds };
+		}
+
+		/// <summary>True when a device is the virtual bus itself.</summary>
+		public static bool IsViGEmBus(DeviceInfo device)
+		{
+			return device != null
+				&& ViGEmBusHardwareIds.Any(x => string.Compare(device.HardwareIds, x, true) == 0);
+		}
+
+		/// <summary>
+		/// True when an identifier carries the XInput marker, which is how Microsoft documents telling an
+		/// XInput device from an ordinary one.
+		/// </summary>
+		public static bool CarriesInputGroup(string hardwareIds)
+		{
+			return !string.IsNullOrEmpty(hardwareIds)
+				&& hardwareIds.IndexOf("IG_", StringComparison.OrdinalIgnoreCase) >= 0;
+		}
+
+		/// <summary>
+		/// Removes pads left behind by earlier runs.
+		/// </summary>
+		/// <param name="rebootNeeded">True when Windows asked for a restart to finish the work.</param>
+		/// <returns>How many were removed.</returns>
+		/// <remarks>
+		/// Windows reports needing a restart as a failure code even though the device has gone. Reading
+		/// it as a failure is why a clean-up can look as though it did nothing while emptying the list.
+		/// </remarks>
+		public static int RemoveLeftoverVirtualPads(out bool rebootNeeded, out Exception error)
+		{
+			rebootNeeded = false;
+			error = null;
+			var removed = 0;
+			foreach (var pad in GetLeftoverVirtualPads())
+			{
+				bool restart;
+				var failure = DeviceDetector.RemoveDevice(pad.DeviceId, 1, out restart);
+				if (failure != null)
+				{
+					error = failure;
+					continue;
+				}
+				removed++;
+				rebootNeeded |= restart;
+			}
+			return removed;
+		}
+
+		#endregion
 
 		#region Driver state
 
@@ -104,20 +345,94 @@ namespace x360ce.App.DInput
 		/// Install Virtual driver.
 		/// </summary>
 		/// <remarks>Must be executed in administrative mode.</remarks>
-		public static void InstallViGEmBus(ProcessWindowStyle style = ProcessWindowStyle.Hidden)
+		/// <summary>
+		/// Which driver command adds a bus and which one changes the bus already there.
+		/// </summary>
+		/// <param name="busCount">How many buses are on the computer now.</param>
+		/// <remarks>
+		/// Named and separated because the difference is invisible from the outside and costs nothing
+		/// until it has been paid many times over. "install" always makes a new bus and never looks at
+		/// what exists, so a computer asked to install ten times ends up with ten buses, none of which
+		/// looks wrong on its own.
+		/// </remarks>
+		public static string GetInstallCommand(int busCount)
+		{
+			return busCount > 0 ? "update" : "install";
+		}
+
+		/// <summary>Every virtual bus currently on this computer.</summary>
+		/// <remarks>
+		/// There is meant to be exactly one. More than one is the result of installing over an
+		/// existing bus, which is a thing this program used to do every time it was asked to install.
+		/// </remarks>
+		public static DeviceInfo[] GetViGEmBusInstances()
+		{
+			return DeviceDetector.GetDevices(null, DIGCF.DIGCF_ALLCLASSES | DIGCF.DIGCF_PRESENT)
+				.Where(IsViGEmBus)
+				.ToArray();
+		}
+
+		/// <summary>
+		/// The driver package for the version of Windows this is running on, as a path inside the
+		/// folder the files are unpacked into.
+		/// </summary>
+		/// <remarks>
+		/// The two packages hold the same driver and differ in how they are signed, which is what
+		/// decides whether Windows will accept them. Windows 10 and later take the one signed for
+		/// Windows 10; everything older takes the other.
+		/// </remarks>
+		static string GetViGEmBusInfPath()
+		{
+			var forWindows10 = JocysCom.ClassLibrary.Controls.IssuesControl.IssueHelper
+				.GetRealOSVersion().Major >= 10;
+			return (forWindows10 ? "Win10" : "WinVS") + "\\ViGEmBus.inf";
+		}
+
+		/// <summary>
+		/// Installs the virtual bus driver, or updates the one already there.
+		/// </summary>
+		/// <returns>True when a bus is present afterwards.</returns>
+		/// <remarks>
+		/// Must be executed in administrative mode.
+		///
+		/// Installing and updating are different commands and picking the wrong one is what left
+		/// this computer with more than one bus. "install" makes a new bus every time it is run and
+		/// never looks at what is already there, so asking twice leaves two, asking ten times leaves
+		/// ten. "update" changes the driver on the bus that exists and makes nothing new.
+		///
+		/// So a bus is made only when there is none, and from then on it is updated in place.
+		/// </remarks>
+		public static bool InstallViGEmBus(ProcessWindowStyle style = ProcessWindowStyle.Hidden)
 		{
 			// Extract files first.
 			ExtractViGemBusFiles(true);
 			var folder = GetViGEmBusPath();
-			var exePath = Path.Combine(folder, GetDevConPath());
-			var osString = JocysCom.ClassLibrary.Controls.IssuesControl.IssueHelper.GetRealOSVersion().Major >= 10
-				? "Win10" : "WinVS";
-			var infFile = string.Format("{0}\\{1}", osString, "ViGEmBus.inf");
-			UacHelper.RunElevated(
-				exePath,
-				// Use last ID.
-				"install " + infFile + " " + ViGEmBusHardwareIds.Last(),
-				style, true);
+			var infFile = GetViGEmBusInfPath();
+			// Use last ID.
+			var hardwareId = ViGEmBusHardwareIds.Last();
+			var command = GetInstallCommand(GetViGEmBusInstances().Length);
+			RunDevCon(folder, command + " " + infFile + " " + hardwareId, style);
+			// Report the state that was actually reached, not the command result.
+			return GetViGEmBusInstances().Any();
+		}
+
+		/// <summary>
+		/// Removes the virtual bus and puts it back, which is what recovers one that has stopped
+		/// working.
+		/// </summary>
+		/// <returns>True when a working bus is present afterwards.</returns>
+		/// <remarks>
+		/// Must be executed in administrative mode.
+		///
+		/// A bus can reach a state where it still answers, still reports itself healthy, and still
+		/// accepts a controller being plugged in, yet never brings that controller up. Nothing about
+		/// it looks wrong from outside, so there is nothing to detect and nothing to repair in place.
+		/// Taking it away and putting it back is what clears it.
+		/// </remarks>
+		public static bool RepairViGEmBus(ProcessWindowStyle style = ProcessWindowStyle.Hidden)
+		{
+			UninstallViGEmBus(style);
+			return InstallViGEmBus(style);
 		}
 
 		/// <summary>
@@ -146,8 +461,17 @@ namespace x360ce.App.DInput
 			// Remove all old instances.
 			foreach (var ViGEmBusHardwareId in ViGEmBusHardwareIds)
 				RunDevCon(folder, "remove " + ViGEmBusHardwareId, style);
+			// Whatever is still there is removed one at a time. Removing by hardware identifier only
+			// reaches a bus that still answers to one, and a computer that has had a bus installed
+			// over an existing one can be left holding a node that no longer does. Leaving even one
+			// behind means the next install updates that one instead of making a working bus.
+			foreach (var bus in GetViGEmBusInstances())
+			{
+				bool restart;
+				DeviceDetector.RemoveDevice(bus.DeviceId, 1, out restart);
+			}
 			// Report the state that was actually reached, not the command result.
-			return GetInstalledViGEmBusVersion() == null;
+			return !GetViGEmBusInstances().Any();
 		}
 
 		#endregion

--- a/App.v4/Common/Options.cs
+++ b/App.v4/Common/Options.cs
@@ -175,6 +175,7 @@ namespace x360ce.App
 		[DefaultValue(true)]
 		public bool MinimizeToTray { get; set; }
 		public bool ExcludeSupplementalDevices { get; set; }
+		[DefaultValue(true), Description("Hide devices this program or another driver created, so it never reads its own output back as an input.")]
 		public bool ExcludeVirtualDevices { get; set; }
 
 		[DefaultValue(true), Description("Autodetect currently focussed game.")]

--- a/App.v4/Common/SettingsManager.Events.cs
+++ b/App.v4/Common/SettingsManager.Events.cs
@@ -29,29 +29,7 @@ namespace x360ce.App
 				// Don't allow controls to fire events.
 				var controls = Current.SettingsMap.Select(x => x.Control).ToArray();
 				foreach (var control in controls)
-				{
-					if (control is NumericUpDown) ((NumericUpDown)control).ValueChanged -= new EventHandler(Control_ValueChanged);
-					if (control is ListBox) ((ListBox)control).SelectedIndexChanged -= new EventHandler(Control_SelectedIndexChanged);
-					if (control is TrackBar) ((TrackBar)control).ValueChanged -= new EventHandler(Control_ValueChanged);
-					if (control is CheckBox) ((CheckBox)control).CheckedChanged -= new EventHandler(Control_CheckedChanged);
-					if (control is ComboBox)
-					{
-						var cbx = (ComboBox)control;
-						if (cbx.DropDownStyle == ComboBoxStyle.DropDownList)
-						{
-							cbx.SelectedIndexChanged -= new EventHandler(Control_TextChanged);
-						}
-						else
-						{
-							cbx.TextChanged -= new EventHandler(Control_TextChanged);
-						}
-					}
-					if (control is DataGridView)
-					{
-						var grid = (DataGridView)control;
-						grid.CellClick -= DataGridView_CellClick;
-					}
-				}
+					SetControlEvents(control, false);
 			}
 		}
 
@@ -77,31 +55,86 @@ namespace x360ce.App
 				if (eventsSuspendCount < 0)
 					throw new Exception("ResumeEvents() executed multiple times.");
 				// Allow controls to fire events.
-				var controls = SettingsManager.Current.SettingsMap.Select(x => x.Control);
+				var controls = SettingsManager.Current.SettingsMap.Select(x => x.Control).ToArray();
 				foreach (var control in controls)
+					SetControlEvents(control, true);
+			}
+		}
+
+		/// <summary>
+		/// Attaches or detaches the events one control reports its own changes through.
+		/// </summary>
+		/// <remarks>
+		/// Which events those are depends on the shape the control is in. A list reports a choice, a
+		/// box being typed into reports the typing, and the two are not interchangeable.
+		///
+		/// Detaching removes both of a combo box's events whatever shape it is in now. A box which
+		/// changed shape after it was attached would otherwise keep the event it was given and lose one
+		/// it never had, and would then report twice, or not at all.
+		/// </remarks>
+		void SetControlEvents(Control control, bool attach)
+		{
+			var upDown = control as NumericUpDown;
+			if (upDown != null)
+			{
+				upDown.ValueChanged -= Control_ValueChanged;
+				if (attach) upDown.ValueChanged += Control_ValueChanged;
+			}
+			var listBox = control as ListBox;
+			if (listBox != null)
+			{
+				listBox.SelectedIndexChanged -= Control_SelectedIndexChanged;
+				if (attach) listBox.SelectedIndexChanged += Control_SelectedIndexChanged;
+			}
+			var trackBar = control as TrackBar;
+			if (trackBar != null)
+			{
+				trackBar.ValueChanged -= Control_ValueChanged;
+				if (attach) trackBar.ValueChanged += Control_ValueChanged;
+			}
+			var checkBox = control as CheckBox;
+			if (checkBox != null)
+			{
+				checkBox.CheckedChanged -= Control_CheckedChanged;
+				if (attach) checkBox.CheckedChanged += Control_CheckedChanged;
+			}
+			var comboBox = control as ComboBox;
+			if (comboBox != null)
+			{
+				comboBox.SelectedIndexChanged -= Control_TextChanged;
+				comboBox.TextChanged -= Control_TextChanged;
+				if (attach)
 				{
-					if (control is NumericUpDown) ((NumericUpDown)control).ValueChanged += new EventHandler(Control_ValueChanged);
-					if (control is ListBox) ((ListBox)control).SelectedIndexChanged += new EventHandler(Control_SelectedIndexChanged);
-					if (control is TrackBar) ((TrackBar)control).ValueChanged += new EventHandler(Control_ValueChanged);
-					if (control is CheckBox) ((CheckBox)control).CheckedChanged += new EventHandler(Control_CheckedChanged);
-					if (control is ComboBox)
-					{
-						var cbx = (ComboBox)control;
-						if (cbx.DropDownStyle == ComboBoxStyle.DropDownList)
-						{
-							cbx.SelectedIndexChanged += new EventHandler(Control_TextChanged);
-						}
-						else
-						{
-							cbx.TextChanged += new EventHandler(Control_TextChanged);
-						}
-					}
-					if (control is DataGridView)
-					{
-						var grid = (DataGridView)control;
-						grid.CellClick += DataGridView_CellClick;
-					}
+					if (comboBox.DropDownStyle == ComboBoxStyle.DropDownList)
+						comboBox.SelectedIndexChanged += Control_TextChanged;
+					else
+						comboBox.TextChanged += Control_TextChanged;
 				}
+			}
+			var grid = control as DataGridView;
+			if (grid != null)
+			{
+				grid.CellClick -= DataGridView_CellClick;
+				if (attach) grid.CellClick += DataGridView_CellClick;
+			}
+		}
+
+		/// <summary>
+		/// Listens to one control again after its shape has changed.
+		/// </summary>
+		/// <remarks>
+		/// A mapping box becomes a box that is typed into when it is switched to a formula, and back to
+		/// a list when it is switched off. The events were chosen when it was attached, long before
+		/// that, so without this a formula being typed reports nothing and only reaches the controller
+		/// when something else happens to save.
+		/// </remarks>
+		public void RewireControl(Control control)
+		{
+			if (control == null)
+				return;
+			lock (eventsLock)
+			{
+				SetControlEvents(control, eventsSuspendCount == 0);
 			}
 		}
 

--- a/App.v4/Common/SettingsManager.cs
+++ b/App.v4/Common/SettingsManager.cs
@@ -583,6 +583,11 @@ namespace x360ce.App
 
 		public void SetComboBoxValue(ComboBox cbx, string text)
 		{
+			// While a box is holding an expression, a control name is written into it at the cursor
+			// rather than replacing what is there. Both the list and the recorder arrive here, so both
+			// keep working while an expression is being typed, and neither needed changing.
+			if (Controls.MapExpressionToggle.InsertControlName(cbx, text))
+				return;
 			// Remove value from other box.
 			var controls = SettingsMap.Select(x => x.Control).ToArray();
 			foreach (Control control in controls)
@@ -654,6 +659,11 @@ namespace x360ce.App
 			else if (control is ComboBox)
 			{
 				var cbx = (ComboBox)control;
+				// A stored expression puts its row into expression mode, so what a person sees matches
+				// what is saved. Without this, a mapping written as a function would open showing an
+				// empty dropdown and the next save would replace it with nothing.
+				if (Controls.MapExpressionToggle.ShowExpression(cbx, value))
+					return;
 				var map = SettingsMap.FirstOrDefault(x => x.Control == control);
 				if (map != null && map.Code != default)
 				{
@@ -762,6 +772,12 @@ namespace x360ce.App
 				var map = SettingsMap.FirstOrDefault(x => x.Control == control);
 				if (map != null && map.Code != default)
 				{
+					// A formula is stored exactly as it was typed. What follows translates the name of
+					// one control into how that control is stored, and a formula is not the name of a
+					// control, so putting it through that turns it into nothing and the row silently
+					// reverts to whatever it was mapped to before.
+					if (MapExpression.IsExpression(control.Text))
+						return control.Text.Trim();
 					v = SettingsConverter.ToIniValue(control.Text);
 					// make sure that disabled button value is "0".
 					if (SettingName.IsButton(key) && string.IsNullOrEmpty(v))

--- a/App.v4/Common/TestDeviceHelper.cs
+++ b/App.v4/Common/TestDeviceHelper.cs
@@ -91,6 +91,13 @@ namespace x360ce.App
 			ud.HidDescription = instanceName;
 			ud.HidClassGuid = new Guid("4d1e55b2-f16f-11cf-88cb-001111000030");
 			ud.IsEnabled = true;
+			// Describe the controls here rather than leaving it to whoever asks for a state. Reading a
+			// state from a device without them fails inside the reading, which reads as a fault in the
+			// device rather than as a step the caller was expected to know about.
+			ud.DeviceObjects = GetDeviceObjects();
+			ud.DiAxeMask = 0x1 | 0x2 | 0x4 | 0x8;
+			ud.DiSliderMask = 0;
+			ud.DeviceEffects = new DeviceEffectItem[0];
 			return ud;
 		}
 

--- a/App.v4/Controls/MapExpressionToggle.cs
+++ b/App.v4/Controls/MapExpressionToggle.cs
@@ -1,0 +1,468 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using x360ce.Engine;
+
+namespace x360ce.App.Controls
+{
+	/// <summary>
+	/// The small "fx" switch that turns a mapping box into an expression, in the manner of a
+	/// spreadsheet formula bar.
+	/// </summary>
+	/// <remarks>
+	/// It is nearly invisible until it is wanted: faint while off, plain while hovered, and fully drawn
+	/// with a border while on. Somebody who never writes an expression should barely notice a row of
+	/// them, and somebody looking for one should find it immediately.
+	/// </remarks>
+	public class MapExpressionToggle : CheckBox
+	{
+
+		/// <summary>Width taken from the box it sits beside, so the row still ends where it did.</summary>
+		public const int ToggleWidth = 20;
+
+		/// <summary>The two letters on the face, which are the same on every one of these.</summary>
+		/// <remarks>
+		/// Kept apart from <see cref="Control.Text"/>, which has to say which row this switch belongs
+		/// to so that it can be told from the other twenty nine.
+		/// </remarks>
+		public const string Label = "fx";
+
+		public MapExpressionToggle()
+		{
+			Appearance = Appearance.Button;
+			FlatStyle = FlatStyle.Flat;
+			// Windows reports a button of this kind by its text, and by nothing else: the accessible
+			// name and the control name are both ignored for it. So the text carries who this switch
+			// belongs to, and the two letters on the face are drawn separately.
+			Text = "Formula";
+			Font = new Font("Segoe UI", 7f, FontStyle.Regular);
+			TextAlign = ContentAlignment.MiddleCenter;
+			Margin = Padding.Empty;
+			Padding = Padding.Empty;
+			TabStop = false;
+			FlatAppearance.BorderSize = 0;
+			FlatAppearance.CheckedBackColor = Color.Transparent;
+			FlatAppearance.MouseOverBackColor = Color.Transparent;
+			FlatAppearance.MouseDownBackColor = Color.Transparent;
+			AccessibleRole = AccessibleRole.CheckButton;
+		}
+
+		/// <summary>
+		/// Describes this switch to a screen reader, and to anything driving the window by name.
+		/// </summary>
+		/// <remarks>
+		/// Given outright rather than left to the default, which reports a button that draws its own
+		/// label as an unnamed blank area with no role. What a person hears, and what a test asks for,
+		/// then does not exist.
+		/// </remarks>
+		protected override AccessibleObject CreateAccessibilityInstance()
+		{
+			return new ToggleAccessibleObject(this);
+		}
+
+		private sealed class ToggleAccessibleObject : Control.ControlAccessibleObject
+		{
+			public ToggleAccessibleObject(MapExpressionToggle owner) : base(owner) { }
+
+			private MapExpressionToggle Toggle { get { return (MapExpressionToggle)Owner; } }
+
+			public override string Name
+			{
+				get { return Owner.AccessibleName ?? "Formula"; }
+				set { Owner.AccessibleName = value; }
+			}
+
+			public override string Description { get { return Owner.AccessibleDescription; } }
+
+			public override AccessibleRole Role { get { return AccessibleRole.CheckButton; } }
+
+			public override AccessibleStates State
+			{
+				get
+				{
+					var state = AccessibleStates.Focusable;
+					if (Toggle.Checked)
+						state |= AccessibleStates.Checked;
+					if (!Toggle.Enabled)
+						state |= AccessibleStates.Unavailable;
+					return state;
+				}
+			}
+
+			/// <summary>What pressing it does now, which depends on which way it is set.</summary>
+			public override string DefaultAction
+			{
+				get { return Toggle.Checked ? "Use a single control" : "Write a formula"; }
+			}
+
+			public override void DoDefaultAction()
+			{
+				Toggle.Checked = !Toggle.Checked;
+			}
+		}
+
+		/// <summary>
+		/// Names this switch after the row it belongs to, for anything driving the window without a
+		/// mouse.
+		/// </summary>
+		/// <param name="rowName">The row, as a person reads it, such as "Right Trigger".</param>
+		/// <remarks>
+		/// Three separate names are needed and they are not interchangeable.
+		///
+		/// The control's own <see cref="Control.Name"/> is what Windows reports as the automation
+		/// identifier. Left unset it reports the window handle instead, which is a different number
+		/// every run, so nothing can ever ask for the same switch twice.
+		///
+		/// The accessible name is what a screen reader says and what a test asks for by name. One name
+		/// shared by thirty switches identifies none of them, so it carries the row.
+		///
+		/// The description says what pressing it does, which the name deliberately does not.
+		/// </remarks>
+		public void NameAfterRow(string rowName)
+		{
+			var plain = string.IsNullOrEmpty(rowName) ? "Mapping" : rowName;
+			Name = plain.Replace(" ", "") + "ExpressionToggle";
+			// The text is what Windows actually reports, so it is the one that has to be distinct.
+			Text = plain + " formula";
+			AccessibleName = Text;
+			AccessibleDescription = "Writes the " + plain + " mapping as a formula instead of choosing one control.";
+		}
+
+		private bool _hovered;
+
+		protected override void OnMouseEnter(EventArgs e)
+		{
+			_hovered = true;
+			Invalidate();
+			base.OnMouseEnter(e);
+		}
+
+		protected override void OnMouseLeave(EventArgs e)
+		{
+			_hovered = false;
+			Invalidate();
+			base.OnMouseLeave(e);
+		}
+
+		protected override void OnCheckedChanged(EventArgs e)
+		{
+			// A switch that is on has to be unmistakable, because everything the box accepts changes.
+			FlatAppearance.BorderSize = Checked ? 1 : 0;
+			Invalidate();
+			base.OnCheckedChanged(e);
+		}
+
+		protected override void OnPaint(PaintEventArgs e)
+		{
+			// Drawn entirely here, without the button underneath. The button pads its own label, which
+			// at this width clips a two letter word down to a stray mark, and letting it draw as well
+			// would put that mark behind this one.
+			var background = Parent == null ? SystemColors.Control : Parent.BackColor;
+			using (var brush = new SolidBrush(background))
+				e.Graphics.FillRectangle(brush, ClientRectangle);
+			// Faint until it is wanted. Blending towards the background rather than using a fixed grey
+			// keeps it faint under any theme, including a dark one.
+			var colour = Checked
+				? SystemColors.WindowText
+				: Blend(background, SystemColors.WindowText, _hovered ? 0.55 : 0.22);
+			if (Checked)
+			{
+				// A switch that is on has to be unmistakable, because everything the box accepts changes.
+				using (var pen = new Pen(colour))
+					e.Graphics.DrawRectangle(pen, 0, 0, Width - 1, Height - 1);
+			}
+			TextRenderer.DrawText(e.Graphics, Label, Font, ClientRectangle, colour,
+				TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding);
+		}
+
+		private static Color Blend(Color from, Color to, double amount)
+		{
+			return Color.FromArgb(
+				(int)(from.R + (to.R - from.R) * amount),
+				(int)(from.G + (to.G - from.G) * amount),
+				(int)(from.B + (to.B - from.B) * amount));
+		}
+
+		#region Attaching to a mapping box
+
+		private static readonly Dictionary<ComboBox, MapExpressionToggle> Attached =
+			new Dictionary<ComboBox, MapExpressionToggle>();
+
+		/// <summary>
+		/// The row a mapping box belongs to, in the words a person reads on screen.
+		/// </summary>
+		/// <remarks>
+		/// Taken from the box's own accessible name where it has one, because that is already the row
+		/// as a person reads it. Otherwise from the control name, which is written as one word.
+		/// </remarks>
+		public static string RowNameFor(ComboBox box)
+		{
+			if (box == null)
+				return null;
+			if (!string.IsNullOrEmpty(box.AccessibleName))
+				return box.AccessibleName;
+			var name = box.Name ?? "";
+			if (name.EndsWith("ComboBox", StringComparison.Ordinal))
+				name = name.Substring(0, name.Length - "ComboBox".Length);
+			// "RightTrigger" reads as "Right Trigger".
+			var spaced = new System.Text.StringBuilder(name.Length + 8);
+			for (int i = 0; i < name.Length; i++)
+			{
+				if (i > 0 && char.IsUpper(name[i]) && !char.IsUpper(name[i - 1]))
+					spaced.Append(' ');
+				spaced.Append(name[i]);
+			}
+			return spaced.ToString();
+		}
+
+		/// <summary>Switch belonging to a mapping box, or null when it has none.</summary>
+		public static MapExpressionToggle For(ComboBox box)
+		{
+			MapExpressionToggle toggle;
+			return box != null && Attached.TryGetValue(box, out toggle) ? toggle : null;
+		}
+
+		/// <summary>True when this box is currently holding an expression rather than one control.</summary>
+		public static bool IsWritingExpression(ComboBox box)
+		{
+			var toggle = For(box);
+			return toggle != null && toggle.Checked;
+		}
+
+		/// <summary>
+		/// Puts a switch immediately before a mapping box, taking its width from the box so that the
+		/// row still ends exactly where it did.
+		/// </summary>
+		/// <remarks>
+		/// Narrowing the box rather than moving it is what keeps this safe on a dense pane: nothing to
+		/// the left or right of the row moves, and the two mirrored columns need no separate treatment.
+		/// </remarks>
+		public static MapExpressionToggle AttachTo(ComboBox box)
+		{
+			if (box == null || box.Parent == null || Attached.ContainsKey(box))
+				return For(box);
+			var toggle = new MapExpressionToggle
+			{
+				Location = new Point(box.Left, box.Top),
+				Size = new Size(ToggleWidth, box.Height),
+				Anchor = box.Anchor,
+			};
+			// Named after the box it belongs to, which already carries the row. "RightTriggerComboBox"
+			// becomes "Right Trigger", so the switch answers to the same words a person reads on screen.
+			toggle.NameAfterRow(RowNameFor(box));
+			box.Left += ToggleWidth;
+			box.Width -= ToggleWidth;
+			box.Parent.Controls.Add(toggle);
+			toggle.BringToFront();
+			Attached.Add(box, toggle);
+			toggle.CheckedChanged += (sender, e) => Switch(box, toggle.Checked);
+			// A row that chose from the list already tells the program the moment the choice is made.
+			// A row being typed into has nothing that says when the typing is finished, so leaving the
+			// box is taken as finished. Without this the formula stays on screen, looking saved, and
+			// is thrown away because nothing ever asked the box what it now held.
+			box.Leave += (sender, e) => Commit(box);
+			// Hovering shows the formula this row's settings already amount to, before anything is
+			// switched. That is where somebody first learns the feature exists, and what their own dead
+			// zone and sensitivity actually do, without having to commit to anything.
+			toggle.MouseEnter += (sender, e) => ShowWhatTheSettingsAmountTo(toggle, box);
+			return toggle;
+		}
+
+		/// <summary>
+		/// Puts a box into expression mode showing a stored expression, when the value is one.
+		/// </summary>
+		/// <returns>True when the value was an expression and the box now shows it.</returns>
+		/// <remarks>
+		/// Loading has to restore the switch as well as the text. A row holding a function whose switch
+		/// was off would show an empty dropdown, tell the person nothing is mapped, and replace their
+		/// function with nothing the next time anything was saved.
+		/// </remarks>
+		public static bool ShowExpression(ComboBox box, string value)
+		{
+			if (!MapExpression.IsExpression(value))
+			{
+				// Coming back to a plain mapping, the switch has to come back off, or the row would
+				// stay editable while holding a value chosen from a list.
+				var current = For(box);
+				if (current != null && current.Checked)
+					current.Checked = false;
+				return false;
+			}
+			// The text is put in first and the switch is set afterwards. Setting the switch first runs
+			// the change-over against whatever the box still held, which seeds a formula from the old
+			// mapping only to overwrite it a line later.
+			box.DropDownStyle = ComboBoxStyle.DropDown;
+			box.Text = value;
+			// A switch that is not there yet does not stop the formula being shown. Saying otherwise
+			// sent the value back down the path that reads it as the name of a control, which turns a
+			// formula into nothing and loses what the person wrote.
+			var toggle = For(box);
+			if (toggle != null)
+				toggle.Checked = true;
+			return true;
+		}
+
+		private static readonly ToolTip Hint = new ToolTip { AutoPopDelay = 20000, InitialDelay = 400 };
+
+		/// <summary>
+		/// Puts this row's dead zone, sensitivity and anti dead zone on the switch as the formula that
+		/// produces them.
+		/// </summary>
+		private static void ShowWhatTheSettingsAmountTo(MapExpressionToggle toggle, ComboBox box)
+		{
+			var seed = SeedFor(box);
+			Hint.SetToolTip(toggle, string.IsNullOrEmpty(seed)
+				? "Write this mapping as a formula."
+				: "Write this mapping as a formula. These settings are the same as:" +
+					Environment.NewLine + seed +
+					Environment.NewLine + Environment.NewLine +
+					"Switching over replaces the dead zone, anti dead zone and sensitivity on this row " +
+					"with the formula, which starts out doing exactly what they do now.");
+		}
+
+		/// <summary>
+		/// This row's current settings written as an expression, or null when there is nothing to write.
+		/// </summary>
+		/// <remarks>
+		/// Only a stick or a trigger is seeded. The shaping settings count in the destination's own
+		/// units, and a button has no travel to shape, so seeding one would invent a number rather than
+		/// preserve a setting.
+		/// </remarks>
+		private static string SeedFor(ComboBox box)
+		{
+			var map = SettingsManager.Current.SettingsMap.FirstOrDefault(x => x.Control == box);
+			if (map == null || string.IsNullOrEmpty(map.IniKey))
+				return null;
+			// Written the way a formula names the control, not the way it is stored. The two disagree
+			// about buttons: storage keeps button one as "1", which inside a formula is the number one.
+			var source = MapExpressionSeed.AsExpressionSource(SettingsConverter.ToIniValue(box.Text));
+			if (string.IsNullOrEmpty(source))
+				return null;
+			var destinationMax = DestinationMax(map.Code);
+			if (destinationMax <= 0f)
+				return MapExpression.Prefix + source;
+			return MapExpressionSeed.FromSettings(source,
+				NumberFor(map, "DeadZone"), NumberFor(map, "AntiDeadZone"), NumberFor(map, "Linear"),
+				destinationMax);
+		}
+
+		/// <summary>Range the row drives, or nought when it is not one that gets shaped.</summary>
+		private static float DestinationMax(MapCode code)
+		{
+			switch (code)
+			{
+				case MapCode.LeftTrigger:
+				case MapCode.RightTrigger:
+					return MapExpressionSeed.TriggerMax;
+				case MapCode.LeftThumbAxisX:
+				case MapCode.LeftThumbAxisY:
+				case MapCode.RightThumbAxisX:
+				case MapCode.RightThumbAxisY:
+					return MapExpressionSeed.ThumbMax;
+				default:
+					return 0f;
+			}
+		}
+
+		/// <summary>
+		/// Value of one of this row's companion settings, read from the control that shows it.
+		/// </summary>
+		/// <remarks>
+		/// Read from the interface rather than from storage so the formula matches what the person is
+		/// looking at, including a change they have made but not yet saved.
+		/// </remarks>
+		private static float NumberFor(SettingsMapItem map, string suffix)
+		{
+			var path = map.IniPath + suffix;
+			var companion = SettingsManager.Current.SettingsMap
+				.FirstOrDefault(x => string.Equals(x.IniPath, path, StringComparison.OrdinalIgnoreCase));
+			if (companion == null)
+				return 0f;
+			var trackBar = companion.Control as TrackBar;
+			if (trackBar != null)
+				return trackBar.Value;
+			var number = companion.Control as NumericUpDown;
+			if (number != null)
+				return (float)number.Value;
+			float parsed;
+			return companion.Control != null
+				&& float.TryParse(companion.Control.Text, System.Globalization.NumberStyles.Float,
+					System.Globalization.CultureInfo.InvariantCulture, out parsed)
+				? parsed : 0f;
+		}
+
+		/// <summary>Tells the program a typed formula is finished, so that it reaches storage.</summary>
+		/// <remarks>
+		/// Deliberately narrow. Only a box holding a formula does this, so no other row changes when
+		/// it gains or loses focus, and nothing that already worked starts behaving differently.
+		/// </remarks>
+		private static void Commit(ComboBox box)
+		{
+			if (box == null || !MapExpression.IsExpression(box.Text))
+				return;
+			SettingsManager.Current.RaiseSettingsChanged(box);
+		}
+
+		/// <summary>Turns writing an expression on or off for one mapping box.</summary>
+		private static void Switch(ComboBox box, bool on)
+		{
+			if (on)
+			{
+				// Editable, because an expression is typed. The list still works, and now inserts a
+				// control name where the cursor is rather than replacing everything.
+				box.DropDownStyle = ComboBoxStyle.DropDown;
+				if (!MapExpression.IsExpression(box.Text))
+					// Seeded from what the row already does, so switching over changes nothing until
+					// the person edits it, and they are shown their own tuning in the new syntax.
+					box.Text = SeedFor(box) ?? MapExpression.Prefix;
+				box.Focus();
+				box.SelectionStart = box.Text.Length;
+				box.SelectionLength = 0;
+			}
+			else
+			{
+				// Leaving expression mode discards the expression: a half-written one is not a mapping,
+				// and keeping it while the box says otherwise would be worse than losing it.
+				if (MapExpression.IsExpression(box.Text))
+					box.Text = "";
+				box.DropDownStyle = ComboBoxStyle.DropDownList;
+			}
+		}
+
+		/// <summary>
+		/// Writes a control name into a box that is holding an expression, at the cursor.
+		/// </summary>
+		/// <returns>True when the box was holding an expression and the name was inserted.</returns>
+		/// <remarks>
+		/// This is what lets the existing list and the recorder keep working while an expression is
+		/// being written: both already produce a control name, and both call the same place to deliver
+		/// it. Inserting rather than replacing is the only difference.
+		/// </remarks>
+		public static bool InsertControlName(ComboBox box, string displayText)
+		{
+			if (!IsWritingExpression(box) || string.IsNullOrEmpty(displayText))
+				return false;
+			// The list shows "Axis 1"; an expression is written in the stored form, "a1".
+			var name = SettingsConverter.ToIniValue(displayText);
+			if (string.IsNullOrEmpty(name))
+				return false;
+			var text = box.Text ?? "";
+			var at = box.SelectionStart;
+			if (at < 0 || at > text.Length)
+				at = text.Length;
+			var remove = Math.Min(box.SelectionLength, text.Length - at);
+			box.Text = text.Substring(0, at) + name + text.Substring(at + remove);
+			// The cursor lands after what was inserted, and the box keeps focus, so a name can be
+			// followed straight away by the arithmetic it belongs to.
+			box.SelectionStart = at + name.Length;
+			box.SelectionLength = 0;
+			box.Focus();
+			return true;
+		}
+
+		#endregion
+
+	}
+}

--- a/App.v4/Controls/MapExpressionToggle.cs
+++ b/App.v4/Controls/MapExpressionToggle.cs
@@ -132,6 +132,24 @@ namespace x360ce.App.Controls
 
 		private bool _hovered;
 
+		/// <summary>Whether what the box holds is a formula the program can run.</summary>
+		public enum FormulaState
+		{
+			/// <summary>Not a formula, so there is nothing to say about it.</summary>
+			None,
+			/// <summary>Understood, compiled, and driving the row now.</summary>
+			Working,
+			/// <summary>Written down but not understood, so the row is doing nothing.</summary>
+			Broken,
+		}
+
+		private FormulaState _state;
+		private string _problem;
+
+		/// <summary>Whether the formula in the box works, as this switch is currently showing it.</summary>
+		public FormulaState State { get { return _state; } }
+
+
 		protected override void OnMouseEnter(EventArgs e)
 		{
 			_hovered = true;
@@ -164,8 +182,11 @@ namespace x360ce.App.Controls
 				e.Graphics.FillRectangle(brush, ClientRectangle);
 			// Faint until it is wanted. Blending towards the background rather than using a fixed grey
 			// keeps it faint under any theme, including a dark one.
+			// While it is on, the colour answers the one question somebody writing a formula has and
+			// cannot see anywhere else: is this working? Green while the row is being driven by it, red
+			// while it is written down but not understood.
 			var colour = Checked
-				? SystemColors.WindowText
+				? StateColour(_state)
 				: Blend(background, SystemColors.WindowText, _hovered ? 0.55 : 0.22);
 			if (Checked)
 			{
@@ -175,6 +196,17 @@ namespace x360ce.App.Controls
 			}
 			TextRenderer.DrawText(e.Graphics, Label, Font, ClientRectangle, colour,
 				TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding);
+		}
+
+		/// <summary>Colour saying whether the formula works, readable on a light or a dark theme.</summary>
+		private static Color StateColour(FormulaState state)
+		{
+			switch (state)
+			{
+				case FormulaState.Working: return Color.FromArgb(0x2E, 0x9E, 0x2E);
+				case FormulaState.Broken: return Color.FromArgb(0xD1, 0x34, 0x38);
+				default: return SystemColors.WindowText;
+			}
 		}
 
 		private static Color Blend(Color from, Color to, double amount)
@@ -258,15 +290,14 @@ namespace x360ce.App.Controls
 			toggle.BringToFront();
 			Attached.Add(box, toggle);
 			toggle.CheckedChanged += (sender, e) => Switch(box, toggle.Checked);
-			// A row that chose from the list already tells the program the moment the choice is made.
-			// A row being typed into has nothing that says when the typing is finished, so leaving the
-			// box is taken as finished. Without this the formula stays on screen, looking saved, and
-			// is thrown away because nothing ever asked the box what it now held.
-			box.Leave += (sender, e) => Commit(box);
+			// Every keystroke is checked, so the switch says whether the formula works while it is
+			// being written. Applying it is not done here: the box reports its own typing once it has
+			// been switched over, the same way every other box that is typed into does.
+			box.TextChanged += (sender, e) => ShowValidity(box);
 			// Hovering shows the formula this row's settings already amount to, before anything is
 			// switched. That is where somebody first learns the feature exists, and what their own dead
 			// zone and sensitivity actually do, without having to commit to anything.
-			toggle.MouseEnter += (sender, e) => ShowWhatTheSettingsAmountTo(toggle, box);
+			toggle.MouseEnter += (sender, e) => ShowHint(toggle, box);
 			return toggle;
 		}
 
@@ -393,16 +424,52 @@ namespace x360ce.App.Controls
 				? parsed : 0f;
 		}
 
-		/// <summary>Tells the program a typed formula is finished, so that it reaches storage.</summary>
+		/// <summary>Reads what the box now holds and shows on the switch whether it works.</summary>
 		/// <remarks>
-		/// Deliberately narrow. Only a box holding a formula does this, so no other row changes when
-		/// it gains or loses focus, and nothing that already worked starts behaving differently.
+		/// Run on every keystroke. Reading a formula this short is far cheaper than the poll it feeds,
+		/// and it is the only way the person can be told which of the two states they are in while they
+		/// are still typing.
 		/// </remarks>
-		private static void Commit(ComboBox box)
+		private static void ShowValidity(ComboBox box)
 		{
-			if (box == null || !MapExpression.IsExpression(box.Text))
+			var toggle = For(box);
+			if (toggle == null)
 				return;
-			SettingsManager.Current.RaiseSettingsChanged(box);
+			var state = FormulaState.None;
+			string problem = null;
+			if (MapExpression.IsExpression(box.Text))
+			{
+				MapExpression parsed;
+				string error;
+				int position;
+				if (MapExpression.TryParse(box.Text, out parsed, out error, out position))
+				{
+					state = FormulaState.Working;
+				}
+				else
+				{
+					state = FormulaState.Broken;
+					problem = error;
+				}
+			}
+			if (toggle._state == state && toggle._problem == problem)
+				return;
+			toggle._state = state;
+			toggle._problem = problem;
+			toggle.Invalidate();
+		}
+
+		/// <summary>What the switch says when it is pointed at, which depends on the state it is in.</summary>
+		private static void ShowHint(MapExpressionToggle toggle, ComboBox box)
+		{
+			if (!toggle.Checked)
+			{
+				ShowWhatTheSettingsAmountTo(toggle, box);
+				return;
+			}
+			Hint.SetToolTip(toggle, toggle._state == FormulaState.Broken
+				? "This formula is not understood, so the row is doing nothing: " + toggle._problem
+				: "This formula is understood and is driving the row.");
 		}
 
 		/// <summary>Turns writing an expression on or off for one mapping box.</summary>
@@ -413,6 +480,12 @@ namespace x360ce.App.Controls
 				// Editable, because an expression is typed. The list still works, and now inserts a
 				// control name where the cursor is rather than replacing everything.
 				box.DropDownStyle = ComboBoxStyle.DropDown;
+				// A box being typed into announces itself through different events than a list, and the
+				// program chose which to listen to when it first attached, long before this. Without
+				// asking it to listen again, a formula reports nothing while it is written and the row
+				// keeps doing whatever it did before. Done before the text is put in, so the formula it
+				// starts with is applied rather than sitting there unused.
+				SettingsManager.Current.RewireControl(box);
 				if (!MapExpression.IsExpression(box.Text))
 					// Seeded from what the row already does, so switching over changes nothing until
 					// the person edits it, and they are shown their own tuning in the new syntax.
@@ -424,11 +497,14 @@ namespace x360ce.App.Controls
 			else
 			{
 				// Leaving expression mode discards the expression: a half-written one is not a mapping,
-				// and keeping it while the box says otherwise would be worse than losing it.
+				// and keeping it while the box says otherwise would be worse than losing it. Cleared
+				// before the shape changes, so the clearing is reported and the row stops at once.
 				if (MapExpression.IsExpression(box.Text))
 					box.Text = "";
 				box.DropDownStyle = ComboBoxStyle.DropDownList;
+				SettingsManager.Current.RewireControl(box);
 			}
+			ShowValidity(box);
 		}
 
 		/// <summary>

--- a/App.v4/Controls/OptionsUserControl.cs
+++ b/App.v4/Controls/OptionsUserControl.cs
@@ -333,8 +333,20 @@ namespace x360ce.App.Controls
 
 		private void ViGEmBusInstallButton_Click(object sender, EventArgs e)
 		{
-			ViGEmBusTextBox.Text = "Installing. Please Wait...";
-			DInput.DInputHelper.CheckInstallVirtualDriver();
+			// The same button installs a driver that is missing and repairs one that is there. A bus
+			// can stop working while still reporting itself healthy, and the moment somebody wants
+			// that put right is the moment this button used to be greyed out.
+			var present = DInput.VirtualDriverInstaller.GetInstalledViGEmBusVersion() != null;
+			if (present)
+			{
+				ViGEmBusTextBox.Text = "Repairing. Please Wait...";
+				Program.RunElevated(AdminCommand.RepairViGEmBus);
+			}
+			else
+			{
+				ViGEmBusTextBox.Text = "Installing. Please Wait...";
+				DInput.DInputHelper.CheckInstallVirtualDriver();
+			}
 			RefreshViGEmBusStatus();
 		}
 
@@ -405,7 +417,10 @@ namespace x360ce.App.Controls
 						? "Not installed"
 						: string.Format("{0} {1}", bus.Description, bus.GetVersion());
 					ControlsHelper.SetText(ViGEmBusTextBox, busStatus);
-					ViGEmBusInstallButton.Enabled = bus.DriverVersion == 0;
+					// Always available, because a bus that is present is exactly the one that might
+					// need putting right. The word changes so it is clear which of the two it will do.
+					ViGEmBusInstallButton.Enabled = true;
+					ViGEmBusInstallButton.Text = bus.DriverVersion == 0 ? "Install" : "Repair";
 					ViGEmBusUninstallButton.Enabled = bus.DriverVersion != 0;
 				});
 			});

--- a/App.v4/Controls/PadControl.cs
+++ b/App.v4/Controls/PadControl.cs
@@ -135,6 +135,16 @@ namespace x360ce.App.Controls
 		{
 			var i = (int)MappedTo - 1;
 			var useXiStates = SettingsManager.Options.GetXInputStates;
+			if (useXiStates)
+			{
+				// Windows decides which of the four places a new controller goes into and does not say,
+				// so the place is looked up rather than assumed to match the controller number. On a
+				// computer with all four places empty this program's first controller was put in the
+				// third; reading the first place showed a controller that was never there.
+				var place = Global.DHelper.XiPlaceForPad[i];
+				if (place >= 0)
+					i = place;
+			}
 			newState = useXiStates
 				? Global.DHelper.LiveXiStates[i]
 				: Global.DHelper.CombinedXiStates[i];
@@ -742,6 +752,11 @@ namespace x360ce.App.Controls
 			var section = string.Format(@"PAD{0}", (int)MappedTo);
 			var item = SettingsManager.AddMap(section, setting, control, MappedTo, code);
 			item.Code = code;
+			// A box that names a control can hold an expression instead, so it gets the switch that
+			// turns one into the other. Every mapping box carries a code and nothing else does, so
+			// this needs no list of its own to fall out of step.
+			if (control is ComboBox && code != default(MapCode))
+				MapExpressionToggle.AttachTo((ComboBox)control);
 		}
 
 		#endregion

--- a/App.v4/Controls/PadControl.cs
+++ b/App.v4/Controls/PadControl.cs
@@ -537,6 +537,16 @@ namespace x360ce.App.Controls
 		}
 		ComboBox _CurrentCbx;
 
+		/// <summary>Box the mapping menu was last opened for.</summary>
+		/// <remarks>
+		/// One menu serves every box on the pad, and a click on one of its items is handled after
+		/// the menu has closed - so after anything else that happened in between. CurrentCbx is
+		/// cleared by opening the same list a second time, by recording, and by the previous click,
+		/// any of which can happen first, leaving the click with nothing to write into. Keeping the
+		/// target here means the menu and the box it belongs to cannot disagree.
+		/// </remarks>
+		ComboBox MenuTargetCbx;
+
 		void ComboBox_DropDown(object sender, EventArgs e)
 		{
 			var cbx = (ComboBox)sender;
@@ -569,7 +579,8 @@ namespace x360ce.App.Controls
 			{
 				if (cbx == DPadComboBox)
 					EnableDPadMenu(true);
-				cbx.ContextMenuStrip.Show(cbx, new Point(0, cbx.Height), ToolStripDropDownDirection.Default);
+				MenuTargetCbx = cbx;
+				menu.Show(cbx, new Point(0, cbx.Height), ToolStripDropDownDirection.Default);
 			}
 			if (cbx.Items.Count > 0)
 				cbx.SelectedIndex = 0;
@@ -979,13 +990,18 @@ namespace x360ce.App.Controls
 		void DiMenuStrip_Click(object sender, EventArgs e)
 		{
 			ToolStripMenuItem item = (ToolStripMenuItem)sender;
+			// The box this menu was opened for. Nothing else can be asked: by now the menu has
+			// closed and CurrentCbx may already have been cleared.
+			var cbx = MenuTargetCbx;
+			if (cbx == null || cbx.IsDisposed)
+				return;
 			Regex rx = new Regex("^(DPad [0-9]+)$");
 			// If this DPad parent menu.
 			if (rx.IsMatch(item.Text))
 			{
-				if (CurrentCbx == DPadComboBox)
+				if (cbx == DPadComboBox)
 				{
-					SettingsManager.Current.SetComboBoxValue(CurrentCbx, item.Text);
+					SettingsManager.Current.SetComboBoxValue(cbx, item.Text);
 					CurrentCbx = null;
 					//DiMenuStrip.Close();
 				}
@@ -994,17 +1010,20 @@ namespace x360ce.App.Controls
 			{
 				if (item.Text == cRecord)
 				{
-					var map = SettingsManager.Current.SettingsMap.First(x => x.Control == CurrentCbx);
-					StartRecording(map);
+					// Swapping the device rebuilds the map while the menu is open, so the row this
+					// box belongs to can be gone by the time [Record] is picked.
+					var map = SettingsManager.Current.SettingsMap.FirstOrDefault(x => x.Control == cbx);
+					if (map != null)
+						StartRecording(map);
 				}
 				else if (item.Text == cEmpty)
 				{
-					SettingsManager.Current.SetComboBoxValue(CurrentCbx, string.Empty);
+					SettingsManager.Current.SetComboBoxValue(cbx, string.Empty);
 					CurrentCbx = null;
 				}
 				else
 				{
-					SettingsManager.Current.SetComboBoxValue(CurrentCbx, item.Text);
+					SettingsManager.Current.SetComboBoxValue(cbx, item.Text);
 					CurrentCbx = null;
 				}
 			}

--- a/App.v4/Controls/UserDevicesUserControl.Designer.cs
+++ b/App.v4/Controls/UserDevicesUserControl.Designer.cs
@@ -49,6 +49,7 @@
 			this.ControllerDeleteButton = new System.Windows.Forms.ToolStripButton();
 			this.HardwareButton = new System.Windows.Forms.ToolStripButton();
 			this.AddDemoDevice = new System.Windows.Forms.ToolStripButton();
+			this.CleanupVirtualPadsButton = new System.Windows.Forms.ToolStripButton();
 			this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
 			this.EnumeratedDevicesButton = new System.Windows.Forms.ToolStripMenuItem();
 			this.HiddenDevicesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -198,6 +199,7 @@
             this.ControllerDeleteButton,
             this.HardwareButton,
             this.AddDemoDevice,
+            this.CleanupVirtualPadsButton,
             this.toolStripDropDownButton1});
 			this.ControllersToolStrip.Location = new System.Drawing.Point(0, 0);
 			this.ControllersToolStrip.Name = "ControllersToolStrip";
@@ -237,23 +239,30 @@
 			// 
 			// AddDemoDevice
 			// 
-			this.AddDemoDevice.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.AddDemoDevice.Image = ((System.Drawing.Image)(resources.GetObject("AddDemoDevice.Image")));
+			this.AddDemoDevice.Image = global::x360ce.App.Properties.Resources.test_16x16;
 			this.AddDemoDevice.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.AddDemoDevice.Name = "AddDemoDevice";
 			this.AddDemoDevice.Size = new System.Drawing.Size(106, 22);
 			this.AddDemoDevice.Text = "Add Demo Device";
 			this.AddDemoDevice.Click += new System.EventHandler(this.AddDemoDevice_Click);
 			// 
+			// CleanupVirtualPadsButton
+			// 
+			this.CleanupVirtualPadsButton.Image = global::x360ce.App.Properties.Resources.remove_16x16;
+			this.CleanupVirtualPadsButton.Name = "CleanupVirtualPadsButton";
+			this.CleanupVirtualPadsButton.Size = new System.Drawing.Size(132, 22);
+			this.CleanupVirtualPadsButton.Text = "Remove Leftover Pads";
+			this.CleanupVirtualPadsButton.ToolTipText = "Remove virtual controllers left behind by earlier runs, which take up the four XInput places.";
+			this.CleanupVirtualPadsButton.Click += new System.EventHandler(this.CleanupVirtualPadsButton_Click);
+			// 
 			// toolStripDropDownButton1
 			// 
-			this.toolStripDropDownButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
 			this.toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.EnumeratedDevicesButton,
             this.HiddenDevicesMenuItem,
             this.UnhideAllDevicesMenuItem,
             this.synchronizeToHidGuardianToolStripMenuItem});
-			this.toolStripDropDownButton1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton1.Image")));
+			this.toolStripDropDownButton1.Image = global::x360ce.App.Properties.Resources.enable_16x16;
 			this.toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.toolStripDropDownButton1.Name = "toolStripDropDownButton1";
 			this.toolStripDropDownButton1.Size = new System.Drawing.Size(100, 22);
@@ -261,6 +270,7 @@
 			// 
 			// EnumeratedDevicesButton
 			// 
+			this.EnumeratedDevicesButton.Image = global::x360ce.App.Properties.Resources.hardware_16x16;
 			this.EnumeratedDevicesButton.Name = "EnumeratedDevicesButton";
 			this.EnumeratedDevicesButton.Size = new System.Drawing.Size(227, 22);
 			this.EnumeratedDevicesButton.Text = "Show Enumerated Devices";
@@ -268,6 +278,7 @@
 			// 
 			// HiddenDevicesMenuItem
 			// 
+			this.HiddenDevicesMenuItem.Image = global::x360ce.App.Properties.Resources.folder_view_16x16;
 			this.HiddenDevicesMenuItem.Name = "HiddenDevicesMenuItem";
 			this.HiddenDevicesMenuItem.Size = new System.Drawing.Size(227, 22);
 			this.HiddenDevicesMenuItem.Text = "Show Hidden Devices";
@@ -275,6 +286,7 @@
 			// 
 			// UnhideAllDevicesMenuItem
 			// 
+			this.UnhideAllDevicesMenuItem.Image = global::x360ce.App.Properties.Resources.ok_16x16;
 			this.UnhideAllDevicesMenuItem.Name = "UnhideAllDevicesMenuItem";
 			this.UnhideAllDevicesMenuItem.Size = new System.Drawing.Size(227, 22);
 			this.UnhideAllDevicesMenuItem.Text = "Unhide All Devices";
@@ -282,6 +294,7 @@
 			// 
 			// synchronizeToHidGuardianToolStripMenuItem
 			// 
+			this.synchronizeToHidGuardianToolStripMenuItem.Image = global::x360ce.App.Properties.Resources.refresh_16x16;
 			this.synchronizeToHidGuardianToolStripMenuItem.Name = "synchronizeToHidGuardianToolStripMenuItem";
 			this.synchronizeToHidGuardianToolStripMenuItem.Size = new System.Drawing.Size(227, 22);
 			this.synchronizeToHidGuardianToolStripMenuItem.Text = "Synchronize To HID Guardian";
@@ -311,6 +324,7 @@
 		private System.Windows.Forms.ToolStripButton RefreshButton;
 		private System.Windows.Forms.ToolStripButton HardwareButton;
 		private System.Windows.Forms.ToolStripButton AddDemoDevice;
+		private System.Windows.Forms.ToolStripButton CleanupVirtualPadsButton;
         private System.Windows.Forms.ToolStripDropDownButton toolStripDropDownButton1;
         private System.Windows.Forms.ToolStripMenuItem EnumeratedDevicesButton;
         private System.Windows.Forms.ToolStripMenuItem HiddenDevicesMenuItem;

--- a/App.v4/Controls/UserDevicesUserControl.cs
+++ b/App.v4/Controls/UserDevicesUserControl.cs
@@ -10,6 +10,7 @@ using JocysCom.ClassLibrary.Controls;
 using System.ComponentModel;
 using JocysCom.ClassLibrary.IO;
 using System.Drawing;
+using x360ce.App.DInput;
 using System.Threading.Tasks;
 using JocysCom.ClassLibrary.Win32;
 using JocysCom.ClassLibrary.Collections;
@@ -220,6 +221,63 @@ namespace x360ce.App.Controls
 			ControlsHelper.CheckTopMost(form);
 			form.ShowDialog();
 			form.Dispose();
+		}
+
+		private void CleanupVirtualPadsButton_Click(object sender, EventArgs e)
+		{
+			var pads = VirtualDriverInstaller.GetLeftoverVirtualPads();
+			if (pads.Length == 0)
+			{
+				MessageBoxForm.Show("No virtual controllers have been left behind.",
+					"Remove Leftover Pads", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				return;
+			}
+			// Say what the trouble is before asking, because the number on its own means nothing to
+			// somebody who does not know that only four XInput places exist.
+			var question = string.Format(
+				"{0} virtual controllers from earlier runs are still present.\r\n\r\n" +
+				"Windows offers only four XInput places, so these take the places this program needs " +
+				"and a controller can appear to move on its own.\r\n\r\n" +
+				"Remove them? Real controllers are not touched.", pads.Length);
+			var answer = MessageBoxForm.Show(question, "Remove Leftover Pads",
+				MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+			if (answer != DialogResult.Yes)
+				return;
+			// Windows does not let an ordinary program remove a device, so this takes the same route
+			// every other administrative action here takes: a second copy of this program starts as
+			// Administrator with the one argument and does the work. Called directly it simply failed,
+			// without saying so, and the pads stayed exactly where they were.
+			var doneHere = Program.RunElevated(AdminCommand.RemoveLeftoverPads);
+			if (doneHere)
+			{
+				// Already running as Administrator, so the work happened in this program and the
+				// outcome is known exactly.
+				bool rebootNeeded;
+				Exception error;
+				var removed = VirtualDriverInstaller.RemoveLeftoverVirtualPads(out rebootNeeded, out error);
+				var result = string.Format("Removed {0} of {1}.", removed, pads.Length);
+				if (rebootNeeded)
+					result += "\r\n\r\nRestart Windows to finish removing them.";
+				if (error != null)
+					result += "\r\n\r\nThe last one that could not be removed reported: " + error.Message;
+				MessageBoxForm.Show(result, "Remove Leftover Pads", MessageBoxButtons.OK,
+					error == null ? MessageBoxIcon.Information : MessageBoxIcon.Warning);
+			}
+			else
+			{
+				// The elevated copy runs on its own and this one cannot see what it did, so the count
+				// is simply taken again once it has had time to finish.
+				var left = VirtualDriverInstaller.GetLeftoverVirtualPads().Length;
+				var removed = pads.Length - left;
+				var result = removed > 0
+					? string.Format("Removed {0} of {1}.", removed, pads.Length)
+					: "Nothing was removed. The request to run as Administrator may have been refused.";
+				if (removed > 0 && left > 0)
+					result += "\r\n\r\nRestart Windows to finish removing the rest.";
+				MessageBoxForm.Show(result, "Remove Leftover Pads", MessageBoxButtons.OK,
+					removed > 0 ? MessageBoxIcon.Information : MessageBoxIcon.Warning);
+			}
+			Global.DHelper.UpdateDevicesEnabled = true;
 		}
 
 		private void AddDemoDevice_Click(object sender, EventArgs e)

--- a/App.v4/Documents/ChangeLog.txt
+++ b/App.v4/Documents/ChangeLog.txt
@@ -1,4 +1,8 @@
-﻿v4.18.38.0 (2026-08-27)
+﻿v4.18.40.0 (2026-08-27)
+- Fixed: A formula had no effect until the box was left.
+- Added: The fx button turns green when the formula works and red when it does not.
+
+v4.18.38.0 (2026-08-27)
 - Fixed: Choosing a mapping from the list could crash the program.
 - Fixed: Program could crash while closing, after its window had gone.
 - Fixed: Program crashed instead of saying the virtual bus driver was missing.

--- a/App.v4/Documents/ChangeLog.txt
+++ b/App.v4/Documents/ChangeLog.txt
@@ -1,4 +1,18 @@
-﻿v4.18.23.0 (2026-08-26)
+﻿v4.18.35.0 (2026-08-27)
+- Added: A mapping row can hold a formula instead of a single control.
+- Added: An fx button on each mapping row turns it into a formula.
+- Added: Formulas can read the clock, in milliseconds since the program started.
+- Added: Issues tab lists virtual controllers left behind by earlier runs and removes them.
+- Fixed: Controller picture stayed grey, or moved while nothing was touched.
+- Fixed: Virtual controllers left behind by earlier runs appeared as real devices and returned after every restart.
+- Fixed: Removing leftover virtual controllers did nothing unless already running as Administrator.
+- Fixed: Installing the virtual bus driver added another one each time.
+- Fixed: Program used a whole processor core while doing nothing.
+- Fixed: Devices tab buttons and the HID Guardian menu had no icons.
+- Changed: Mapping rows can be reached by name by a screen reader.
+- Known: A formula is limited to 16 characters, which is what a mapping is stored in.
+
+v4.18.23.0 (2026-08-26)
 - Fixed: Crash reports named no file or line, so a failure could not be traced to code.
 - Fixed: A failure in work sent to the interface was reported late and without a stack.
 - Fixed: Errors were never recorded, so problems could not be reported.

--- a/App.v4/Documents/ChangeLog.txt
+++ b/App.v4/Documents/ChangeLog.txt
@@ -1,4 +1,9 @@
-﻿v4.18.35.0 (2026-08-27)
+﻿v4.18.38.0 (2026-08-27)
+- Fixed: Choosing a mapping from the list could crash the program.
+- Fixed: Program could crash while closing, after its window had gone.
+- Fixed: Program crashed instead of saying the virtual bus driver was missing.
+
+v4.18.35.0 (2026-08-27)
 - Added: A mapping row can hold a formula instead of a single control.
 - Added: An fx button on each mapping row turns it into a formula.
 - Added: Formulas can read the clock, in milliseconds since the program started.

--- a/App.v4/Documents/Help.rtf
+++ b/App.v4/Documents/Help.rtf
@@ -46,5 +46,73 @@ Solution 2: If you \ul can't separate pedals\ulnone :\par
 1\f1\lang1063 .\lang39  Open \cf1 X360\lang1063 CE\cf0 .\lang39\line 2\lang1063 .\lang39  Set LEFT "Trigger" \cf4\lang1063 [\lang39 drop\lang1063 -\lang39 down\lang1063 ]\cf0  \lang39 value to\lang1063 : \lang39 Sliders \f2\u8594?\f0\lang39  Half \f2\u8594?\f0\lang39  \cf1 HSlider 1\cf0\f1\lang1063 .\line\lang39 3\lang1063 .\lang39  Set RIGHT "Trigger" \cf4\lang1063 [\lang39 drop\lang1063 -\lang39 down\lang1063 ] \cf0\lang39 value to\lang1063 :\lang39  Sliders \f2\u8594?\f0\lang39  Inverted Half \f2\u8594?\f0\lang39  \cf1 IHSlider 1\cf0\f1\lang1063 .\line\lang39 4\lang1063 .\lang39  Test pedals.\par
 \b What are real life steering wheel degrees?\b0\par
 1080\'b0 (3.0 x 360\'b0) - Heavy cars, trucks.\line   900\'b0 (2.5 x 360\'b0) - Average road cars, sports cars.\line   720\'b0 (2.0 x 360\'b0) - Drift cars. Multiple classes of Rally cars (group N).\line   540\'b0 (1.5 x 360\'b0) - GT1 and 3 spec race cars, WRC Rally cars.\line   360\'b0 (1.0 x 360\'b0) - Formula 1 cars.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Expressions: working out a value from other controls\b0\par
+\pard\nowidctlpar\sa200\sl276\slmult1\f0\fs18\lang39 A mapping normally names one control. It can instead work one out, by starting the value with an equals sign. For example \cf1 =a1*abs(a1)\cf0  gives fine control near the centre of a stick and full speed at its edge, which is the response curve most games offer as an aim setting.\par
+\pard\nowidctlpar\sa200\sl276\slmult1\f0\fs18\lang39 Values are scaled for you before the sum and fitted to whatever they drive afterwards, so you write plain numbers and never have to know a device\rquote s range. Going past the limit is safe: it simply reaches full travel.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Controls you can read\b0\par
+\pard\nowidctlpar\sa200\sl276\slmult1\f0\fs18\lang39 A control is written as a letter and a number, the same way mappings are stored. Inside an expression the letter is always required, because a bare number means the number itself.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 a1\cf0  Axis, -1 to 1. A stick or wheel that rests in the middle and moves both ways.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 b1\cf0  Button, 0 or 1. 0 while released, 1 while held.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 s1\cf0  Slider, 0 to 1. A throttle, pedal or dial that rests at one end.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 x1\cf0  Half axis, 0 to 1. One half of an axis on its own, so the two halves can drive different things.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 h1\cf0  Half slider, 0 to 1. One half of a slider on its own.\par\par now \endash  Clock, counts up. Milliseconds since the program started. Divide by 1000 for seconds, or by 60000 for minutes. The only source that is not a control.\par Counting minutes: =now/60000
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 p1\cf0  D-pad, 0 to 1. The hat switch read as a direction rather than as separate buttons.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 d1\cf0  D-pad button, 0 or 1. One direction of the hat switch.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Operators that combine two values\b0\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 +\cf0  Add. =a1+a2 - both controls move the same output.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 -\cf0  Subtract. =a1-a2 - one control opposes the other, as two pedals on one axis.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 *\cf0  Multiply. =a1*1.5 - makes a control travel further for the same movement.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 /\cf0  Divide. =a1/2 - makes a control travel less, for finer control.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 %\cf0  Remainder. =a1%0.25 - what is left after dividing, useful for repeating steps.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 ^\cf0  Power. =a1^2 - raises to a power. 2^3^2 is 2^9, and -2^2 is -4.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Operators that act on one value\b0\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 -\cf0  Negate. =-a1 - reverses the direction of a control.\par
+\pard\nowidctlpar\sa200\sl276\slmult1\f0\fs18\lang39 Brackets group a part of the sum, as in =(a1+a2)*0.5, and a comma separates the values a function takes, as in =min(a1,a2).\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Functions\b0\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 abs (1) - size of a value, ignoring its direction.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 sign (1) - direction alone: -1, 0 or 1.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 sqrt (1) - square root.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 exp (1) - the number e raised to this power.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 floor (1) - rounds down to a whole number.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 ceil (1) - rounds up to a whole number.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 round (1) - rounds to a whole number. A half goes to the even neighbour, so round(2.5) is 2 and round(3.5) is 4.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 sin (1) - sine. Angles are in degrees, so sin(90) is 1.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 cos (1) - cosine. Angles are in degrees.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 tan (1) - tangent. Angles are in degrees.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 asin (1) - the angle, in degrees, whose sine is this value.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 acos (1) - the angle, in degrees, whose cosine is this value.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 atan (1) - the angle, in degrees, whose tangent is this value.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 min (2) - the smaller of two values.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 max (2) - the larger of two values.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 pow (2) - the first value raised to the power of the second, the same as ^.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 log (2) - logarithm of the first value in the base given by the second.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 clamp (3) - holds a value between a low and a high limit.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 deadzone (2) - Ignores the first part of a movement, then stretches what is left over the full travel.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 antideadzone (2) - Lifts any movement above a floor, so a game that ignores small values still notices. Nothing is lifted at rest.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 curve (2) - Bends the middle of the travel and leaves both ends alone, the same as the Sensitivity setting.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Turning a tuned row into a formula\b0\par
+\pard\nowidctlpar\sa200\sl276\slmult1\f0\fs18\lang39 The dead zone, anti dead zone and sensitivity on a row are replaced by its formula, not applied on top of it, so what you write is what the game receives. Nothing is lost when you switch: the box is filled with the formula that produces exactly what those settings were already doing. Hover the fx button to see that formula before you switch.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Buttons and logic\b0\par
+\pard\nowidctlpar\sa200\sl276\slmult1\f0\fs18\lang39 A button is 0 or 1, so ordinary arithmetic already does the work of and, or and not. There is nothing extra to learn.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =b1*b2\cf0  - and, true only while both are held.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =max(b1,b2)\cf0  - or, true while either is held.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =1-b1\cf0  - not, true while it is released.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =abs(b1-b2)\cf0  - either one but not both.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1*b1\cf0  - full speed only while the button is held.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1*(0.5+b1*0.5)\cf0  - half speed until the button is held.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Examples\b0\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1*abs(a1)\cf0  - fine control near the centre, full speed at the edge.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =sign(a1)*sqrt(abs(a1))\cf0  - quick to respond, gentler at the edge.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1*1.5\cf0  - more sensitive everywhere.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1*0.5\cf0  - less sensitive, for aiming through a scope.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1*(0.5+a2*0.5)\cf0  - walk slowly, run when the trigger is held.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1-0.05\cf0  - correct a stick that drifts off centre.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =max(a1,0)\cf0  - one pedal axis split into the accelerator.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =-min(a1,0)\cf0  - the same axis, its braking half.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 \cf1 =a1-a2\cf0  - separate accelerator and brake onto one axis.\par
+\pard\nowidctlpar\sb120\sa200\sl276\slmult1\b\f0\fs18\lang39 Things worth knowing\b0\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 Anything that is not a real number, such as dividing by zero, becomes 0.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 A decimal point is always a dot, whatever language Windows is set to.\par
+\pard\nowidctlpar\sl276\slmult1\f0\fs18\lang39 Older versions of this program ignore expressions, so a configuration using one loses that mapping when it is opened in them.\par
 }
  

--- a/App.v4/Issues/LeftoverVirtualPadsIssue.cs
+++ b/App.v4/Issues/LeftoverVirtualPadsIssue.cs
@@ -1,0 +1,53 @@
+﻿using JocysCom.ClassLibrary.Controls.IssuesControl;
+
+namespace x360ce.App.Issues
+{
+	/// <summary>
+	/// Virtual controllers the bus is still holding for runs that ended without shutting down.
+	/// </summary>
+	/// <remarks>
+	/// The bus keeps a controller plugged in until it is told to unplug it. A run that ends normally
+	/// tells it; one that is killed, or that crashes, never gets the chance, and the controller stays
+	/// plugged in until Windows is restarted.
+	///
+	/// Windows offers four places for a controller of this kind and fills them in order, so ones left
+	/// behind take the first places and the controller this program creates lands after them. What a
+	/// person sees is a picture that never moves, or one that moves on its own, with nothing anywhere
+	/// saying why. This is that missing explanation.
+	/// </remarks>
+	class LeftoverVirtualPadsIssue : IssueItem
+	{
+		public LeftoverVirtualPadsIssue() : base()
+		{
+			Name = "Leftover Virtual Controllers";
+			FixName = "Remove";
+		}
+
+		public override void CheckTask()
+		{
+			var pads = DInput.VirtualDriverInstaller.GetLeftoverVirtualPads();
+			if (pads.Length == 0)
+			{
+				SetSeverity(IssueSeverity.None);
+				return;
+			}
+			// Said as what it costs the person rather than as a count of devices, because the number on
+			// its own means nothing to somebody who does not know that only four places exist.
+			SetSeverity(IssueSeverity.Moderate, 0, string.Format(
+				"{0} virtual controllers left behind by earlier runs are still present. They take the " +
+				"places this program needs, so a controller can look dead or move on its own.",
+				pads.Length));
+		}
+
+		public override void FixTask()
+		{
+			// Windows does not let an ordinary program remove a device, so this takes the route every
+			// other administrative action here takes: a second copy of this program starts as
+			// Administrator with one argument, does the work, and ends.
+			Program.RunElevated(AdminCommand.RemoveLeftoverPads);
+			// Devices are read again so the list on screen matches what is now there.
+			Global.DHelper.UpdateDevicesEnabled = true;
+		}
+
+	}
+}

--- a/App.v4/MainForm.cs
+++ b/App.v4/MainForm.cs
@@ -1302,6 +1302,22 @@ namespace x360ce.App
 			SettingsManager.Current.RaiseSettingsChanged(null);
 		}
 
+		/// <summary>
+		/// Stop listening for the current game once this window is gone.
+		/// </summary>
+		/// <remarks>
+		/// The event is static, so nothing else lets go of this form. The window this program
+		/// watches keeps changing while the process shuts down, and each change asks which game is
+		/// in front; the answer arrives here and reads controls which have already been disposed.
+		/// A disposed ToolStripComboBox returns null for its ComboBox, so the read fails rather
+		/// than doing nothing.
+		/// </remarks>
+		protected override void OnFormClosed(FormClosedEventArgs e)
+		{
+			SettingsManager.CurrentGame_PropertyChanged -= CurrentGame_PropertyChanged;
+			base.OnFormClosed(e);
+		}
+
 		private void GamesToolStrip_Resize(object sender, EventArgs e)
 		{
 			GameToCustomizeComboBox.AutoSize = false;

--- a/App.v4/MainForm.cs
+++ b/App.v4/MainForm.cs
@@ -353,6 +353,16 @@ namespace x360ce.App
 				{
 					list.Remove(virtualDevice);
 				}
+				// The pads this program feeds are XInput devices, and XInput devices appear in
+				// DirectInput enumeration as well. Reading one back makes the program take its own
+				// output as an input, add it as a new device, and repeat. A device whose hardware
+				// identifier carries the IG_ marker is an XInput device, which is how Microsoft
+				// documents telling the two apart.
+				var xInputDevices = list.Where(IsXInputDevice).ToArray();
+				foreach (var xInputDevice in xInputDevices)
+				{
+					list.Remove(xInputDevice);
+				}
 			}
 			// Move gaming wheels to the top index position by default.
 			// Games like GTA need wheel to be first device to work properly.
@@ -392,6 +402,21 @@ namespace x360ce.App
 				SettingsManager.UserSettings.Items.Add(item);
 			}
 		}
+
+		/// <summary>True when a device is an XInput device, real or created by a driver.</summary>
+		/// <remarks>
+		/// Read from the identifiers the device already carries, so this costs nothing and needs no
+		/// second enumeration of the system.
+		/// </remarks>
+		static bool IsXInputDevice(UserDevice device)
+		{
+			// The identifiers are included because a pad created moments ago has no hardware list yet.
+			return DInput.VirtualDriverInstaller.CarriesInputGroup(device.HidHardwareIds)
+				|| DInput.VirtualDriverInstaller.CarriesInputGroup(device.DevHardwareIds)
+				|| DInput.VirtualDriverInstaller.CarriesInputGroup(device.HidDeviceId)
+				|| DInput.VirtualDriverInstaller.CarriesInputGroup(device.DevDeviceId);
+		}
+
 
 		/// <summary>
 		/// Link control with INI key. Value/Text of control will be automatically tracked and INI file updated.
@@ -1055,7 +1080,8 @@ namespace x360ce.App
 					new CppX64RuntimeInstallIssue(),
 					new HotfixIssue(),
 					new XboxDriversIssue(),
-					new VirtualDeviceDriverIssue()
+					new VirtualDeviceDriverIssue(),
+					new LeftoverVirtualPadsIssue()
 				);
 				IssuesPanel.IsSuspended = new Func<bool>(IssuesPanel_IsSuspended);
 				IssuesPanel.CheckCompleted += IssuesPanel_CheckCompleted;
@@ -1580,6 +1606,9 @@ namespace x360ce.App
 			{
 				DebugPanel.ShowPanel();
 			}
+			// Counted at the moment the window opens, before this program has plugged anything in, so
+			// that everything found is by definition somebody else's. Shown a little later, because
+			// loading the settings restores the tip in the header and would wipe it.
 		}
 
 		private void AddGameButton_Click(object sender, EventArgs e)

--- a/App.v4/Program.AdminCommands.cs
+++ b/App.v4/Program.AdminCommands.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 
 namespace x360ce.App
 {
@@ -57,6 +58,30 @@ namespace x360ce.App
 			if (ic.Parameters.ContainsKey(AdminCommand.UninstallViGEmBus.ToString()))
 			{
 				DInput.VirtualDriverInstaller.UninstallViGEmBus();
+				return true;
+			}
+			if (ic.Parameters.ContainsKey(AdminCommand.RepairViGEmBus.ToString()))
+			{
+				var repaired = DInput.VirtualDriverInstaller.RepairViGEmBus();
+				Console.WriteLine(repaired
+					? "Virtual bus removed and put back."
+					: "Virtual bus could not be put back. Restart Windows and try again.");
+				Environment.ExitCode = repaired ? 0 : 1;
+				return true;
+			}
+			if (ic.Parameters.ContainsKey(AdminCommand.RemoveLeftoverPads.ToString()))
+			{
+				bool rebootNeeded;
+				Exception error;
+				var removed = DInput.VirtualDriverInstaller.RemoveLeftoverVirtualPads(out rebootNeeded, out error);
+				// Windows reports needing a restart with a failure code even though the device has
+				// gone, so the exit code says only whether anything went wrong that was not that.
+				Console.WriteLine("Removed {0} leftover virtual pad(s).", removed);
+				if (rebootNeeded)
+					Console.WriteLine("Restart Windows to finish removing them.");
+				if (error != null)
+					Console.WriteLine("Last failure: {0}", error.Message);
+				Environment.ExitCode = error == null ? 0 : 1;
 				return true;
 			}
 			if (ic.Parameters.ContainsKey(AdminCommand.UninstallHidGuardian.ToString()))

--- a/App.v4/Program.cs
+++ b/App.v4/Program.cs
@@ -34,6 +34,20 @@ namespace x360ce.App
 		{
 			// Fix: System.TimeoutException: The operation has timed out. at System.Windows.Threading.Dispatcher.InvokeImpl
 			AppContext.SetSwitch("Switch.MS.Internal.DoNotInvokeInWeakEventTableShutdownListener", true);
+			// Set here rather than in a configuration file, because the program ships as one file
+			// and no configuration file travels with it. Left in app.config alone, none of these
+			// take effect for anyone who downloads it.
+			//
+			// Symbols are built into the program rather than shipped beside it, and the runtime
+			// ignores symbols in that form for a program built against a framework older than
+			// 4.7.2 unless it is asked. Without this a crash report names no file and no line.
+			AppContext.SetSwitch("Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces", false);
+			// Without these every control reaches a screen reader as an unnamed blank area, and
+			// the items of a tool strip are not reachable at all.
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures", false);
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.2", false);
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.3", false);
+			AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.4", false);
 			// First: Set working folder to the path of executable.
 			var fi = new FileInfo(Application.ExecutablePath);
 			Directory.SetCurrentDirectory(fi.Directory.FullName);

--- a/App.v4/Properties/AssemblyInfo.cs
+++ b/App.v4/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Resources;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.18.35.0")]
-[assembly: AssemblyFileVersion("4.18.35.0")]
+[assembly: AssemblyVersion("4.18.38.0")]
+[assembly: AssemblyFileVersion("4.18.38.0")]
 [assembly: AssemblyDelaySign(false)]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/App.v4/Properties/AssemblyInfo.cs
+++ b/App.v4/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Resources;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.18.38.0")]
-[assembly: AssemblyFileVersion("4.18.38.0")]
+[assembly: AssemblyVersion("4.18.40.0")]
+[assembly: AssemblyFileVersion("4.18.40.0")]
 [assembly: AssemblyDelaySign(false)]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/App.v4/Properties/AssemblyInfo.cs
+++ b/App.v4/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Resources;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.18.23.0")]
-[assembly: AssemblyFileVersion("4.18.23.0")]
+[assembly: AssemblyVersion("4.18.35.0")]
+[assembly: AssemblyFileVersion("4.18.35.0")]
 [assembly: AssemblyDelaySign(false)]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/App.v4/ViGEm/Client/ViGEmClient.Native.cs
+++ b/App.v4/ViGEm/Client/ViGEmClient.Native.cs
@@ -59,7 +59,7 @@ namespace Nefarius.ViGEm.Client
             static extern ushort vigem_target_get_pid(PVIGEM_TARGET target);
 
             [DllImport("vigemclient.dll", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-            static extern uint vigem_target_get_index(PVIGEM_TARGET target);
+            internal static extern uint vigem_target_get_index(PVIGEM_TARGET target);
 
             [DllImport("vigemclient.dll", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
             static extern VIGEM_TARGET_TYPE vigem_target_get_type(PVIGEM_TARGET target);

--- a/App.v4/ViGEm/Client/ViGEmClient.x360ce.cs
+++ b/App.v4/ViGEm/Client/ViGEmClient.x360ce.cs
@@ -214,6 +214,12 @@ namespace Nefarius.ViGEm.Client
 				VIGEM_ERROR error;
 				if (!IsLoaded)
 					LoadLibrary();
+				// Without the native library there is nothing to allocate against, and the call
+				// below would throw DllNotFoundException on the input thread and take the whole
+				// program down. A missing library is reported the same way a missing C++ runtime
+				// is: no bus, which the Issues tab already explains and offers to fix.
+				if (!IsLoaded)
+					return false;
 				var client = new ViGEmClient(out error);
 				if (error == VIGEM_ERROR.VIGEM_ERROR_NONE)
 				{

--- a/App.v4/ViGEm/Client/ViGEmTarget.cs
+++ b/App.v4/ViGEm/Client/ViGEmTarget.cs
@@ -26,6 +26,25 @@ namespace Nefarius.ViGEm.Client
         protected PVIGEM_TARGET NativeHandle { get; set; }
 
         /// <summary>
+        /// The number the bus knows this controller by, which also appears in its name in Windows.
+        /// </summary>
+        /// <remarks>
+        /// This is the clear reference to a controller this program created. The bus does not record
+        /// which program created what, and Windows has no field saying so either, so without this
+        /// there is no way to tell this program's own controller from one left behind by a run that
+        /// died. Getting that wrong means offering to remove the controller currently in use.
+        /// </remarks>
+        public uint Serial
+        {
+            get
+            {
+                return NativeHandle == IntPtr.Zero
+                    ? 0
+                    : ViGEmClient.NativeMethods.vigem_target_get_index(NativeHandle);
+            }
+        }
+
+        /// <summary>
         ///     Gets the Vendor ID this device will present to the system.
         /// </summary>
         public ushort VendorId { get; protected set; }

--- a/App.v4/app.config
+++ b/App.v4/app.config
@@ -1,17 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup>
-  <runtime>
-    <!--
-      IgnorePortablePDBsInStackTraces=false opts in to file and line information from
-      portable symbols. The runtime ignores them for an application built against a
-      framework older than 4.7.2 unless asked, which is why crash reports named no line.
-
-      Opt in to the accessibility support that .NET Framework 4.7.1 and later ship behind
-      these switches. Without them every control reaches a screen reader as an unnamed
-      generic pane, and the items of a tool strip - including the error count in the status
-      bar - are not reachable at all.
-    -->
-    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false;Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false"/>
-  </runtime>
 </configuration>

--- a/App.v4/x360ce.App.v4.csproj
+++ b/App.v4/x360ce.App.v4.csproj
@@ -215,6 +215,9 @@
     </Compile>
     <Compile Include="Controls\PadTabPages\General\PadControlImager.cs" />
     <Compile Include="Controls\PadTabPages\IPadControl.cs" />
+    <Compile Include="Controls\MapExpressionToggle.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\PresetsGridUserControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -382,6 +385,7 @@
     <Compile Include="Issues\ExeFileIssue.cs" />
     <Compile Include="Issues\HotfixIssue.cs" />
     <Compile Include="Issues\VirtualDeviceDriverIssue.cs" />
+    <Compile Include="Issues\LeftoverVirtualPadsIssue.cs" />
     <Compile Include="Issues\XboxDriversIssue.cs" />
     <Compile Include="MainForm.Tray.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
@@ -406,6 +410,7 @@
     <Compile Include="ViGEm\Client\ViGEmClient.cs" />
     <Compile Include="ViGEm\Client\ViGEmClient.Native.cs" />
     <Compile Include="ViGEm\Client\ViGEmClient.x360ce.cs" />
+
     <Compile Include="ViGEm\Client\ViGEmTarget.cs" />
     <Compile Include="ViGEm\Client\Enums\VIGEM_ERROR.cs" />
     <Compile Include="ViGEm\HidGuardianHelper.cs" />

--- a/Build_All.cmd
+++ b/Build_All.cmd
@@ -16,28 +16,36 @@ if "%CONFIG%"=="" set "CONFIG=Release"
 set "SLN=%~dp0x360ce.slnx"
 
 :: ---------------------------------------------------------------------------
-:: Locate MSBuild via vswhere.
+:: Locate MSBuild. vswhere is asked first because it is the supported way, but it
+:: reports nothing when the installer's instance record is missing, which happens
+:: after some upgrades and after the package cache is cleaned even though Visual
+:: Studio itself works. The install folders are then searched directly rather than
+:: giving up on a machine which can build perfectly well. The search is handed to
+:: PowerShell so it picks the same file Documents\App_0_Release.ps1 picks, and it
+:: runs outside an if block because the paths it names contain brackets.
 :: ---------------------------------------------------------------------------
+set "MSBUILD="
+set "_TMP=%TEMP%\x360ce_msbuild_path.txt"
 set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-if not exist "%VSWHERE%" (
-    echo ERROR: vswhere.exe not found at "%VSWHERE%".
+if exist "%VSWHERE%" (
+    "%VSWHERE%" -latest -prerelease -find "MSBuild\**\Bin\MSBuild.exe" > "%_TMP%" 2>nul
+    set /p MSBUILD=<"%_TMP%"
+    del "%_TMP%" >nul 2>&1
+)
+if defined MSBUILD goto :HaveMSBuild
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$roots=@(); foreach ($base in [Environment]::GetFolderPath('ProgramFiles'), [Environment]::GetFolderPath('ProgramFilesX86')) { $dir = Join-Path $base 'Microsoft Visual Studio'; if (Test-Path $dir) { $roots += $dir } }; if ($roots.Count) { $found = Get-ChildItem -Path $roots -Filter MSBuild.exe -Recurse -File -ErrorAction SilentlyContinue | Where-Object { $_.DirectoryName -notmatch 'amd64|arm64' } | Sort-Object FullName -Descending | Select-Object -First 1; if ($found) { $found.FullName } }" > "%_TMP%" 2>nul
+set /p MSBUILD=<"%_TMP%"
+del "%_TMP%" >nul 2>&1
+:HaveMSBuild
+if not defined MSBUILD (
+    echo ERROR: MSBuild.exe not found.
     echo        Install Visual Studio 2022+ or VS 2026 Build Tools, including the
     echo        "MSVC v141 - VS 2017 C++ build tools" individual component, which a
     echo        default installation does not carry.
     exit /b 1
 )
-
-set "_TMP=%TEMP%\x360ce_msbuild_path.txt"
-"%VSWHERE%" -latest -find "MSBuild\**\Bin\MSBuild.exe" > "%_TMP%"
-set "MSBUILD="
-set /p MSBUILD=<"%_TMP%"
-del "%_TMP%" >nul 2>&1
-if not defined MSBUILD (
-    echo ERROR: MSBuild.exe not found via vswhere.
-    exit /b 1
-)
 if not exist "%MSBUILD%" (
-    echo ERROR: MSBuild.exe path returned by vswhere does not exist: "%MSBUILD%"
+    echo ERROR: MSBuild.exe path does not exist: "%MSBUILD%"
     exit /b 1
 )
 

--- a/Data/Change Scripts/2026-08-27_Widen_Mapping_Columns_To_128.sql
+++ b/Data/Change Scripts/2026-08-27_Widen_Mapping_Columns_To_128.sql
@@ -1,0 +1,151 @@
+﻿/*
+    Widens the mapping columns of [dbo].[x360ce_PadSettings] from VARCHAR(16) to VARCHAR(128).
+
+    Why
+        A mapping column used to hold only a control name, such as 'a1', which fits in sixteen
+        characters. It can now also hold a formula, such as '=sign(a1)*deadzone(abs(a1),0.24)',
+        which does not. Sixteen characters is the smallest limit in the chain, so it, and not the
+        program, decides how long a formula may be.
+
+    What it costs
+        Nothing measurable. VARCHAR does not pad, so no row grows and no page is rewritten;
+        widening within the 8000 byte VARCHAR limit is a change to the catalogue only. No index
+        touches these columns, so nothing is rebuilt and no query plan changes. Every stored
+        checksum stays valid, because the checksum is taken over the values and the values are
+        unchanged.
+
+    Row size
+        The row's declared maximum goes from 1,248 bytes to 4,608, against a limit of 8,060. That
+        limit is why 128 was chosen: at 256 the declared row would be 8,448 and the table would no
+        longer be creatable.
+
+    Safe to run twice. A column that is already 128 or wider is left alone.
+*/
+SET NOCOUNT ON;
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+DECLARE @Table SYSNAME = N'[dbo].[x360ce_PadSettings]';
+DECLARE @NewSize INT = 128;
+
+IF OBJECT_ID(@Table, 'U') IS NULL
+BEGIN
+    RAISERROR('Table %s does not exist. Nothing to widen.', 16, 1, @Table);
+    RETURN;
+END;
+
+/* The columns that hold a mapping. Every other column in this table holds a number, and a number
+   never needed more than sixteen characters. */
+DECLARE @Mapping TABLE ([Name] SYSNAME PRIMARY KEY);
+INSERT INTO @Mapping ([Name]) VALUES
+    ('ButtonA'),
+    ('ButtonB'),
+    ('ButtonBack'),
+    ('ButtonGuide'),
+    ('ButtonStart'),
+    ('ButtonX'),
+    ('ButtonY'),
+    ('DPad'),
+    ('DPadDown'),
+    ('DPadLeft'),
+    ('DPadRight'),
+    ('DPadUp'),
+    ('LeftShoulder'),
+    ('LeftThumbAxisX'),
+    ('LeftThumbAxisY'),
+    ('LeftThumbButton'),
+    ('LeftThumbDown'),
+    ('LeftThumbLeft'),
+    ('LeftThumbRight'),
+    ('LeftThumbUp'),
+    ('LeftTrigger'),
+    ('RightShoulder'),
+    ('RightThumbAxisX'),
+    ('RightThumbAxisY'),
+    ('RightThumbButton'),
+    ('RightThumbDown'),
+    ('RightThumbLeft'),
+    ('RightThumbRight'),
+    ('RightThumbUp'),
+    ('RightTrigger');
+
+/* A name that is not in the table means this script and the schema have drifted apart. Say so
+   rather than silently widening a smaller set than intended. */
+IF EXISTS (
+    SELECT 1 FROM @Mapping m
+    WHERE NOT EXISTS (
+        SELECT 1 FROM sys.columns c
+        WHERE c.object_id = OBJECT_ID(@Table) AND c.name = m.[Name]))
+BEGIN
+    SELECT [Missing column] = m.[Name] FROM @Mapping m
+    WHERE NOT EXISTS (
+        SELECT 1 FROM sys.columns c
+        WHERE c.object_id = OBJECT_ID(@Table) AND c.name = m.[Name]);
+    RAISERROR('The columns listed above are not in %s. Widen nothing until that is explained.', 16, 1, @Table);
+    RETURN;
+END;
+
+/* An index over one of these would make ALTER COLUMN fail part way through, leaving the table
+   half widened. Find out before starting rather than during. */
+IF EXISTS (
+    SELECT 1
+    FROM sys.index_columns ic
+    JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+    JOIN @Mapping m ON m.[Name] = c.name
+    WHERE ic.object_id = OBJECT_ID(@Table))
+BEGIN
+    RAISERROR('An index covers one of the mapping columns. Drop it, widen, then recreate it.', 16, 1);
+    RETURN;
+END;
+
+DECLARE @Name SYSNAME, @Sql NVARCHAR(MAX), @Widened INT = 0, @Skipped INT = 0;
+
+/* Counted before anything is altered. Counting afterwards would count the columns this run just
+   widened and report them as having needed nothing. */
+SELECT @Skipped = COUNT(*)
+FROM sys.columns c
+JOIN @Mapping m ON m.[Name] = c.name
+WHERE c.object_id = OBJECT_ID(@Table)
+  AND (c.max_length >= @NewSize OR c.max_length = -1);
+
+DECLARE Widen CURSOR LOCAL FAST_FORWARD FOR
+    SELECT c.name
+    FROM sys.columns c
+    JOIN @Mapping m ON m.[Name] = c.name
+    WHERE c.object_id = OBJECT_ID(@Table)
+      AND c.max_length <> -1               /* already VARCHAR(MAX): leave it */
+      AND c.max_length < @NewSize          /* already wide enough: leave it */
+    ORDER BY c.name;
+
+OPEN Widen;
+FETCH NEXT FROM Widen INTO @Name;
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    /* NOT NULL is repeated deliberately. ALTER COLUMN without it makes the column nullable.
+       The DEFAULT constraint is unaffected and does not need dropping. */
+    SET @Sql = N'ALTER TABLE ' + @Table + N' ALTER COLUMN ' + QUOTENAME(@Name)
+             + N' VARCHAR(' + CAST(@NewSize AS NVARCHAR(10)) + N') NOT NULL;';
+    EXEC sp_executesql @Sql;
+    SET @Widened = @Widened + 1;
+    FETCH NEXT FROM Widen INTO @Name;
+END;
+CLOSE Widen;
+DEALLOCATE Widen;
+
+PRINT 'Widened ' + CAST(@Widened AS VARCHAR(10)) + ' column(s) to VARCHAR(' + CAST(@NewSize AS VARCHAR(10)) + ').';
+PRINT 'Already wide enough: ' + CAST(@Skipped AS VARCHAR(10)) + ' column(s).';
+GO
+
+/* What the table looks like afterwards. All thirty mapping columns should read 128, and nothing
+   else should appear in this list. */
+SELECT
+    [Column] = c.name,
+    [Size]   = c.max_length,
+    [Null]   = CASE WHEN c.is_nullable = 1 THEN 'yes' ELSE 'no' END
+FROM sys.columns c
+WHERE c.object_id = OBJECT_ID(N'[dbo].[x360ce_PadSettings]')
+  AND c.system_type_id = TYPE_ID('varchar')
+  AND c.max_length <> 16
+ORDER BY c.name;
+GO

--- a/Documents/App_0_Release.ps1
+++ b/Documents/App_0_Release.ps1
@@ -133,10 +133,35 @@ if (-not $SkipSign) {
     }
 }
 
-$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found. Visual Studio is required." }
-$msbuild = & $vswhere -latest -prerelease -find '**\Bin\MSBuild.exe' | Select-Object -First 1
-if (-not $msbuild) { throw "MSBuild.exe not found." }
+# vswhere is asked first because it is the supported way to find an installation. It
+# reports nothing when the installer's instance record is missing, which happens after
+# some upgrades and after the package cache is cleaned, even though Visual Studio itself
+# works. The folders it would have pointed at are then searched directly rather than
+# failing on a machine which can build perfectly well.
+function Find-VsTool {
+    param(
+        [Parameter(Mandatory = $true)][string]$Pattern,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $found = & $vswhere -latest -prerelease -find $Pattern | Select-Object -First 1
+        if ($found) { return $found }
+    }
+    $roots = @(
+        "${env:ProgramFiles}\Microsoft Visual Studio",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio"
+    ) | Where-Object { Test-Path $_ }
+    # Newest edition first, so a side by side install picks the same one vswhere would,
+    # and the processor specific copies are left out because they are not what it reports.
+    $found = Get-ChildItem -Path $roots -Filter (Split-Path -Leaf $Pattern) -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -notmatch 'amd64|arm64' } |
+        Sort-Object FullName -Descending | Select-Object -First 1
+    if (-not $found) { throw "$Name not found. Visual Studio is required." }
+    return $found.FullName
+}
+
+$msbuild = Find-VsTool -Pattern '**\Bin\MSBuild.exe' -Name 'MSBuild.exe'
 
 #------------------------------------------------------------------------------
 # Steps.

--- a/Documents/App_0_Release.ps1
+++ b/Documents/App_0_Release.ps1
@@ -163,6 +163,20 @@ function Find-VsTool {
 
 $msbuild = Find-VsTool -Pattern '**\Bin\MSBuild.exe' -Name 'MSBuild.exe'
 
+# The installation which owns the MSBuild being used. Derived from that path rather
+# than looked up separately, so the tools checked here are certain to be the tools
+# the build then runs with.
+function Get-VsRoot {
+    param([Parameter(Mandatory = $true)][string]$MsBuildPath)
+    $dir = Split-Path -Parent $MsBuildPath
+    while ($dir) {
+        $parent = Split-Path -Parent $dir
+        if ((Split-Path -Leaf $dir) -eq 'MSBuild') { return $parent }
+        $dir = $parent
+    }
+    return $null
+}
+
 #------------------------------------------------------------------------------
 # Steps.
 #------------------------------------------------------------------------------
@@ -210,7 +224,7 @@ function Remove-BuildOutput {
 # previous output before it fails, and the native output is not in source
 # control, so missing tools have to be found before the clean, not after it.
 function Assert-Toolsets {
-    $vsRoot = & $vswhere -latest -prerelease -property installationPath | Select-Object -First 1
+    $vsRoot = Get-VsRoot $msbuild
     $installed = New-Object System.Collections.Generic.List[string]
     $vcDir = if ($vsRoot) { Join-Path $vsRoot "MSBuild\Microsoft\VC" } else { $null }
     if ($vcDir -and (Test-Path -LiteralPath $vcDir)) {

--- a/Engine/Common/MapExpression.cs
+++ b/Engine/Common/MapExpression.cs
@@ -1,0 +1,714 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq.Expressions;
+
+namespace x360ce.Engine
+{
+	/// <summary>
+	/// A mapping value that computes its result from other sources, written as "=a1*abs(a1)".
+	/// </summary>
+	/// <remarks>
+	/// Expressions arrive from a shared database and are therefore written by strangers. The grammar is
+	/// deliberately closed: numbers, source references, four operators, brackets, unary minus, and a fixed
+	/// table of functions. It has no way to name a type, reach a member, loop, or recurse, so the only cost
+	/// an author can impose is arithmetic, and the node cap bounds that.
+	///
+	/// Values are normalised before evaluation and clamped afterwards by the caller, so an expression is
+	/// written in plain numbers and never has to know a device's range.
+	/// </remarks>
+	public sealed class MapExpression
+	{
+
+		#region Limits
+
+		/// <summary>Marks a value as an expression rather than a plain source reference.</summary>
+		public const string Prefix = "=";
+
+		/// <summary>
+		/// Longest accepted expression. Checked against the raw text before anything parses it.
+		/// </summary>
+		/// <remarks>
+		/// This is the width of the column an expression is stored in, not a number chosen here.
+		/// Storage has to be the binding limit: a cap larger than the column would let somebody write
+		/// an expression that passes every check and is then silently cut short when it is saved,
+		/// which is worse than refusing it while they are still looking at it.
+		///
+		/// Sixteen is short. It is enough for the simple things people actually write, such as
+		/// "=a5*2" or "=a1*0.5", and not enough to write a dead zone and a curve out in full. The
+		/// column is widened in a later release and this number moves with it; until then the two
+		/// must agree, and a test holds them together.
+		/// </remarks>
+		public const int MaxLength = 16;
+
+		/// <summary>
+		/// Deepest accepted nesting. Counted by scanning the raw text, then again while parsing.
+		/// </summary>
+		/// <remarks>
+		/// A stack overflow cannot be caught: it ends the process with no handler and no chance to save.
+		/// The raw scan is therefore the real defence, because it runs before any recursion starts.
+		/// </remarks>
+		public const int MaxDepth = 16;
+
+		/// <summary>Most nodes an expression may build. Bounds evaluation cost and compiled size.</summary>
+		public const int MaxNodes = 128;
+
+		/// <summary>Most distinct sources one expression may read.</summary>
+		public const int MaxReferences = 8;
+
+		#endregion
+
+		/// <summary>Source letters, matching the stored mapping format, plus 'b' for a button.</summary>
+		/// <remarks>
+		/// Storage writes a button as a bare number, which cannot be told from a number literal inside an
+		/// expression. Within an expression the letter is therefore required and buttons take 'b'.
+		/// </remarks>
+		internal const string TypeLetters = "abdhpsx";
+
+		/// <summary>The one source that is not a control: how long the program has been running.</summary>
+		/// <remarks>
+		/// Written as a word rather than a letter and a number, because there is only ever one of it.
+		/// Its type letter is deliberately not among the ones above, so that "t1" is still refused: a
+		/// person who wants the clock writes what they mean.
+		/// </remarks>
+		public const string TimeName = "now";
+
+		/// <summary>Reference type used for <see cref="TimeName"/>.</summary>
+		public const char TimeType = 't';
+
+		/// <summary>Angles are in degrees, because a person writing sin(90) means a quarter turn.</summary>
+		internal const double DegreesToRadians = Math.PI / 180.0;
+
+		private MapExpression(string text, Func<float[], float> compiled, IList<MapReference> references)
+		{
+			Text = text;
+			_compiled = compiled;
+			References = new System.Collections.ObjectModel.ReadOnlyCollection<MapReference>(references);
+		}
+
+		private readonly Func<float[], float> _compiled;
+
+		/// <summary>The expression as written, including its prefix.</summary>
+		public string Text { get; private set; }
+
+		/// <summary>
+		/// Sources this expression reads, in the order <see cref="Evaluate"/> expects their values.
+		/// </summary>
+		public IList<MapReference> References { get; private set; }
+
+		/// <summary>True when a stored value is an expression rather than a plain source reference.</summary>
+		public static bool IsExpression(string value)
+		{
+			return !string.IsNullOrEmpty(value) && value[0] == '=';
+		}
+
+		/// <summary>
+		/// Computes the result. Values are supplied in the order given by <see cref="References"/>.
+		/// </summary>
+		/// <remarks>
+		/// A result that is not a finite number becomes zero, so a division by zero or a square root of a
+		/// negative number reaches the pad as a resting value rather than as rubbish.
+		/// </remarks>
+		public float Evaluate(float[] values)
+		{
+			// A caller that supplies too few values gets a resting result rather than an exception.
+			// This runs on the thread that feeds the pad, where a throw would end the feed entirely.
+			if (values == null || values.Length < References.Count)
+				return 0f;
+			var result = _compiled(values);
+			return float.IsNaN(result) || float.IsInfinity(result) ? 0f : result;
+		}
+
+		/// <summary>
+		/// Parses and compiles an expression. Returns false for anything it does not fully understand.
+		/// </summary>
+		/// <param name="value">The stored value, including the leading '=' prefix.</param>
+		/// <param name="result">The compiled expression, or null.</param>
+		/// <param name="error">Why it was rejected, or null.</param>
+		/// <param name="position">Where in the text the fault is, or -1.</param>
+		/// <remarks>
+		/// Bad input is expected input, so this never throws for it. Every rejection happens before the
+		/// expression is compiled, and compilation is reached only by text the grammar fully accepts.
+		/// </remarks>
+		public static bool TryParse(string value, out MapExpression result, out string error, out int position)
+		{
+			result = null;
+			error = null;
+			position = -1;
+			if (!IsExpression(value))
+			{
+				error = "Not an expression.";
+				return false;
+			}
+			return Read(value, out result, out error, out position);
+		}
+
+		/// <summary>
+		/// Reads the text. Called once for each distinct mapping, not once per poll.
+		/// </summary>
+		/// <remarks>
+		/// Nothing is remembered here on purpose. A store of readings would hold every compiled method
+		/// alive for as long as the program runs, and a compiled method cannot be unloaded. The place
+		/// that stops this being read repeatedly is the pad's own list of mappings, which is rebuilt
+		/// only when a mapping actually changes; a formula is therefore read once when it is set, and
+		/// the compiled result lives exactly as long as the mapping that uses it.
+		/// </remarks>
+		private static bool Read(string value, out MapExpression result, out string error, out int position)
+		{
+			result = null;
+			error = null;
+			position = -1;
+			// Guard the raw text first. Everything below this point recurses, and the checks that
+			// prevent a stack overflow cannot themselves be allowed to overflow.
+			if (!CheckRawText(value, ref error, ref position))
+				return false;
+			var body = value.Substring(Prefix.Length);
+			try
+			{
+				var parser = new Parser(body);
+				var tree = parser.ParseExpression();
+				parser.ExpectEnd();
+				var lambda = Expression.Lambda<Func<float[], float>>(
+					Expression.Convert(tree, typeof(float)), parser.Values);
+				result = new MapExpression(value, lambda.Compile(), parser.References);
+				return true;
+			}
+			catch (FormatException ex)
+			{
+				error = ex.Message;
+				position = ex.Data.Contains("pos") ? (int)ex.Data["pos"] + Prefix.Length : -1;
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Rejects text that is too long, too deeply nested, or contains a character the grammar has no
+		/// use for, before any parsing begins.
+		/// </summary>
+		private static bool CheckRawText(string value, ref string error, ref int position)
+		{
+			if (value.Length > MaxLength)
+			{
+				error = string.Format("Longer than {0} characters.", MaxLength);
+				position = MaxLength;
+				return false;
+			}
+			var depth = 0;
+			// Where each unclosed bracket was opened, so an unfinished expression can point at the
+			// bracket that is waiting rather than at the end of the text, which tells nobody anything.
+			var opened = new int[MaxDepth + 1];
+			for (int i = Prefix.Length; i < value.Length; i++)
+			{
+				var c = value[i];
+				if (c == '(')
+				{
+					if (depth <= MaxDepth)
+						opened[depth] = i;
+					depth++;
+					if (depth > MaxDepth)
+					{
+						error = string.Format("Nested deeper than {0} brackets.", MaxDepth);
+						position = i;
+						return false;
+					}
+				}
+				else if (c == ')')
+				{
+					depth--;
+					if (depth < 0)
+					{
+						error = "Closing bracket without an opening one.";
+						position = i;
+						return false;
+					}
+				}
+				else if (!IsAllowed(c))
+				{
+					error = string.Format("'{0}' has no meaning here.", c);
+					position = i;
+					return false;
+				}
+			}
+			if (depth != 0)
+			{
+				error = "Opening bracket without a closing one.";
+				position = opened[Math.Min(depth, MaxDepth) - 1];
+				return false;
+			}
+			return true;
+		}
+
+		/// <summary>Characters the grammar can use. Everything else is refused outright.</summary>
+		private static bool IsAllowed(char c)
+		{
+			if (c >= '0' && c <= '9') return true;
+			if (c >= 'a' && c <= 'z') return true;
+			if (c >= 'A' && c <= 'Z') return true;
+			// Note what is absent: '!' has no meaning here, so a factorial cannot be written. It is the
+			// one arithmetic operation whose cost grows without bound from a short input, and it earned
+			// another expression library a published advisory for exactly that.
+			return c == '+' || c == '-' || c == '*' || c == '/' || c == '%' || c == '^'
+				|| c == '.' || c == ',' || c == ' ';
+		}
+
+		#region Functions
+
+		private static readonly Dictionary<string, FunctionInfo> Functions = CreateFunctions();
+
+		/// <summary>Every function the grammar accepts, with how many values each takes.</summary>
+		/// <remarks>
+		/// Exposed so the Help page can be checked against the parser rather than written beside it. A
+		/// function that exists here without being documented is a capability nobody was told about.
+		/// </remarks>
+		public static IDictionary<string, int> FunctionArity
+		{
+			get
+			{
+				var map = new SortedDictionary<string, int>(StringComparer.Ordinal);
+				foreach (var pair in Functions)
+					map.Add(pair.Key, pair.Value.Arity);
+				return map;
+			}
+		}
+
+		/// <summary>Source letters an expression may read.</summary>
+		public static string SourceLetters { get { return TypeLetters; } }
+
+		private sealed class FunctionInfo
+		{
+			public int Arity;
+			public Func<Expression[], Expression> Build;
+		}
+
+		private static Dictionary<string, FunctionInfo> CreateFunctions()
+		{
+			// Ordinal comparison, because under some languages a case-insensitive compare maps 'I' to a
+			// letter that no longer matches, and 'min' would stop being found.
+			var map = new Dictionary<string, FunctionInfo>(StringComparer.Ordinal);
+			Add(map, "abs", 1, a => Call("Abs", a[0]));
+			// Not Math.Sign, which throws for a value that is not a number rather than returning one.
+			// A throw here would leave the input thread through Evaluate, past the sanitiser.
+			Add(map, "sign", 1, a => Expression.Condition(
+				Expression.GreaterThan(a[0], Expression.Constant(0.0)), Expression.Constant(1.0),
+				Expression.Condition(
+					Expression.LessThan(a[0], Expression.Constant(0.0)), Expression.Constant(-1.0),
+					Expression.Constant(0.0))));
+			Add(map, "sqrt", 1, a => Call("Sqrt", a[0]));
+			Add(map, "exp", 1, a => Call("Exp", a[0]));
+			Add(map, "floor", 1, a => Call("Floor", a[0]));
+			Add(map, "ceil", 1, a => Call("Ceiling", a[0]));
+			Add(map, "round", 1, a => Call("Round", a[0]));
+			// Angles are degrees throughout, so a person writing sin(90) gets the quarter turn they
+			// meant. Conversions between degrees and radians are deliberately absent: with degree
+			// trigonometry, sin(rad(90)) would silently compute the sine of 1.57 degrees.
+			Add(map, "sin", 1, a => Call("Sin", ToRadians(a[0])));
+			Add(map, "cos", 1, a => Call("Cos", ToRadians(a[0])));
+			Add(map, "tan", 1, a => Call("Tan", ToRadians(a[0])));
+			Add(map, "asin", 1, a => ToDegrees(Call("Asin", a[0])));
+			Add(map, "acos", 1, a => ToDegrees(Call("Acos", a[0])));
+			Add(map, "atan", 1, a => ToDegrees(Call("Atan", a[0])));
+			Add(map, "min", 2, a => Call("Min", a[0], a[1]));
+			Add(map, "max", 2, a => Call("Max", a[0], a[1]));
+			Add(map, "pow", 2, a => Call("Pow", a[0], a[1]));
+			Add(map, "log", 2, a => Call("Log", a[0], a[1]));
+			// The limits are sorted, so writing them the wrong way round holds the value between them
+			// rather than silently pinning every input to one number.
+			Add(map, "clamp", 3, a => Call("Min", Call("Max", a[0], Call("Min", a[1], a[2])), Call("Max", a[1], a[2])));
+			// The three shaping steps a mapping row already offers, written as functions so a row that
+			// is switched to an expression reads as what it does rather than as a wall of arithmetic.
+			// Spelled out, the busiest row came to over three hundred characters because each part had
+			// to be repeated; named, it fits in sixty and can be read aloud.
+			Add(map, "deadzone", 2, a => DeadZone(a[0], a[1]));
+			Add(map, "antideadzone", 2, a => AntiDeadZone(a[0], a[1]));
+			Add(map, "curve", 2, a => Curve(a[0], a[1]));
+			return map;
+		}
+
+		private static void Add(Dictionary<string, FunctionInfo> map, string name, int arity, Func<Expression[], Expression> build)
+		{
+			map.Add(name, new FunctionInfo { Arity = arity, Build = build });
+		}
+
+		private static Expression ToRadians(Expression degrees)
+		{
+			return Expression.Multiply(degrees, Expression.Constant(DegreesToRadians));
+		}
+
+		private static Expression ToDegrees(Expression radians)
+		{
+			return Expression.Divide(radians, Expression.Constant(DegreesToRadians));
+		}
+
+		/// <summary>Direction of a value as -1, 0 or 1, without throwing for one that is not a number.</summary>
+		private static Expression SignOf(Expression value)
+		{
+			return Expression.Condition(
+				Expression.GreaterThan(value, Expression.Constant(0.0)), Expression.Constant(1.0),
+				Expression.Condition(
+					Expression.LessThan(value, Expression.Constant(0.0)), Expression.Constant(-1.0),
+					Expression.Constant(0.0)));
+		}
+
+		/// <summary>
+		/// Ignores the first part of a movement, then stretches what is left back over the full travel.
+		/// </summary>
+		private static Expression DeadZone(Expression value, Expression amount)
+		{
+			return Expression.Divide(
+				Call("Max", Expression.Subtract(value, amount), Expression.Constant(0.0)),
+				Expression.Subtract(Expression.Constant(1.0), amount));
+		}
+
+		/// <summary>
+		/// Lifts any movement above a floor, so a game that ignores small values still notices.
+		/// </summary>
+		/// <remarks>
+		/// Nothing is lifted at rest. Multiplying by the direction does that, because the direction of
+		/// nought is nought - otherwise a stick sitting still would drive the game constantly.
+		/// </remarks>
+		private static Expression AntiDeadZone(Expression value, Expression amount)
+		{
+			return Expression.Multiply(SignOf(value),
+				Expression.Add(amount, Expression.Multiply(
+					Call("Abs", value), Expression.Subtract(Expression.Constant(1.0), amount))));
+		}
+
+		/// <summary>
+		/// Bends the middle of the travel while leaving both ends where they are.
+		/// </summary>
+		/// <remarks>
+		/// The same curve the Sensitivity setting applies. A positive amount makes the start gentler,
+		/// a negative one makes it quicker.
+		/// </remarks>
+		private static Expression Curve(Expression value, Expression amount)
+		{
+			var v = Call("Abs", value);
+			var one = Expression.Constant(1.0);
+			var gentle = Expression.Add(v, Expression.Multiply(
+				Expression.Subtract(Expression.Subtract(one, Call("Sqrt", Expression.Subtract(one, Expression.Multiply(v, v)))), v),
+				Call("Abs", amount)));
+			var quick = Expression.Add(v, Expression.Multiply(
+				Expression.Subtract(Call("Sqrt", Expression.Subtract(one,
+					Expression.Multiply(Expression.Subtract(one, v), Expression.Subtract(one, v)))), v),
+				Call("Abs", amount)));
+			return Expression.Multiply(SignOf(value),
+				Expression.Condition(Expression.GreaterThanOrEqual(amount, Expression.Constant(0.0)), gentle, quick));
+		}
+
+		/// <summary>
+		/// Binds one named method on <see cref="Math"/>, chosen here at build time.
+		/// </summary>
+		/// <remarks>
+		/// The name comes from this file and never from the expression, so an author cannot reach a method
+		/// the table does not already list.
+		/// </remarks>
+		private static Expression Call(string method, params Expression[] args)
+		{
+			var types = new Type[args.Length];
+			for (int i = 0; i < args.Length; i++)
+				types[i] = typeof(double);
+			if (method == "Sign")
+				return Expression.Call(typeof(Math).GetMethod("Sign", types), args);
+			return Expression.Call(typeof(Math).GetMethod(method, types), args);
+		}
+
+		#endregion
+
+		#region Parser
+
+		/// <summary>Recursive descent over the closed grammar, counting nodes and depth as it goes.</summary>
+		private sealed class Parser
+		{
+			public Parser(string text)
+			{
+				_text = text;
+				Values = Expression.Parameter(typeof(float[]), "v");
+				References = new List<MapReference>();
+			}
+
+			private readonly string _text;
+			private int _at;
+			private int _nodes;
+			private int _depth;
+
+			public ParameterExpression Values { get; private set; }
+			public IList<MapReference> References { get; private set; }
+
+			public Expression ParseExpression()
+			{
+				return ParseAdditive();
+			}
+
+			public void ExpectEnd()
+			{
+				SkipSpace();
+				if (_at < _text.Length)
+					throw Fault(string.Format("'{0}' was not expected here.", _text[_at]), _at);
+			}
+
+			// Additive and multiplicative both loop rather than recurse on their right operand, so
+			// "10-4-3" is 3 and "100/10/2" is 5. Recursing right is silently wrong and never throws.
+			private Expression ParseAdditive()
+			{
+				var left = ParseMultiplicative();
+				while (true)
+				{
+					SkipSpace();
+					if (Peek() == '+') { _at++; left = Node(Expression.Add(left, ParseMultiplicative())); }
+					else if (Peek() == '-') { _at++; left = Node(Expression.Subtract(left, ParseMultiplicative())); }
+					else return left;
+				}
+			}
+
+			private Expression ParseMultiplicative()
+			{
+				var left = ParseUnary();
+				while (true)
+				{
+					SkipSpace();
+					if (Peek() == '*') { _at++; left = Node(Expression.Multiply(left, ParseUnary())); }
+					else if (Peek() == '/') { _at++; left = Node(Expression.Divide(left, ParseUnary())); }
+					else if (Peek() == '%') { _at++; left = Node(Expression.Modulo(left, ParseUnary())); }
+					else return left;
+				}
+			}
+
+			private Expression ParseUnary()
+			{
+				SkipSpace();
+				if (Peek() == '-')
+				{
+					_at++;
+					// Counted like any other nesting. A run of signs descends once per sign and opens no
+					// bracket, so a cap that watched only brackets would miss the very shape that was
+					// measured ending another parser's process.
+					Enter();
+					var negated = Node(Expression.Negate(ParseUnary()));
+					Leave();
+					return negated;
+				}
+				// There is deliberately no unary plus. It computes nothing that its absence does not,
+				// and every operator the grammar carries is one more shape to reason about.
+				return ParsePower();
+			}
+
+			/// <summary>
+			/// Raising to a power, which binds tighter than multiplying and looser than negating.
+			/// </summary>
+			/// <remarks>
+			/// Two conventions have to hold together and neither raises an error when wrong. It groups
+			/// to the right, so 2^3^2 is 2^9 rather than 8^2. And negation applies to the result, so
+			/// -2^2 is -4 rather than 4. Reading the exponent as a unary term gives both, and also lets
+			/// 2^-1 mean a half.
+			/// </remarks>
+			private Expression ParsePower()
+			{
+				var left = ParsePrimary();
+				SkipSpace();
+				if (Peek() != '^')
+					return left;
+				_at++;
+				return Node(Call("Pow", left, ParseUnary()));
+			}
+
+			private Expression ParsePrimary()
+			{
+				SkipSpace();
+				if (_at >= _text.Length)
+					throw Fault("The expression ends before it is complete.", _at);
+				var c = Peek();
+				if (c == '(')
+					return ParseBracketed();
+				if (c >= '0' && c <= '9' || c == '.')
+					return ParseNumber();
+				if (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z')
+					return ParseName();
+				throw Fault(string.Format("'{0}' was not expected here.", c), _at);
+			}
+
+			private Expression ParseBracketed()
+			{
+				Enter();
+				_at++;
+				var inner = ParseAdditive();
+				SkipSpace();
+				if (Peek() != ')')
+					throw Fault("A closing bracket is missing.", _at);
+				_at++;
+				Leave();
+				return inner;
+			}
+
+			private Expression ParseNumber()
+			{
+				var start = _at;
+				while (_at < _text.Length && (_text[_at] >= '0' && _text[_at] <= '9' || _text[_at] == '.'))
+					_at++;
+				var raw = _text.Substring(start, _at - start);
+				double number;
+				// AllowDecimalPoint alone, so a thousands separator is refused rather than silently
+				// dropped: with the wider styles "1,000" parses as 1000 and no error is ever raised.
+				if (!double.TryParse(raw, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
+					throw Fault(string.Format("'{0}' is not a number.", raw), start);
+				return Node(Expression.Constant(number));
+			}
+
+			private Expression ParseName()
+			{
+				var start = _at;
+				while (_at < _text.Length && (_text[_at] >= 'a' && _text[_at] <= 'z' || _text[_at] >= 'A' && _text[_at] <= 'Z'))
+					_at++;
+				var name = _text.Substring(start, _at - start);
+				var digitsAt = _at;
+				while (_at < _text.Length && _text[_at] >= '0' && _text[_at] <= '9')
+					_at++;
+				var digits = _text.Substring(digitsAt, _at - digitsAt);
+				// No space is skipped here: a bracket is part of the call, so "abs (1)" is a mistake
+				// rather than a call written loosely.
+				if (Peek() == '(')
+					return ParseCall(name, digits, start);
+				if (digits.Length == 0)
+				{
+					// The clock is the one source written as a word, because there is only one of it.
+					if (string.Equals(name, TimeName, StringComparison.OrdinalIgnoreCase))
+						return Reference(new MapReference(TimeType, 1), start);
+					throw Fault(string.Format("'{0}' is not a source or a function.", name), start);
+				}
+				return ParseReference(name, digits, start);
+			}
+
+			private Expression ParseCall(string name, string digits, int start)
+			{
+				if (digits.Length != 0)
+					throw Fault(string.Format("'{0}{1}' is not a function.", name, digits), start);
+				FunctionInfo function;
+				if (!Functions.TryGetValue(name.ToLowerInvariant(), out function))
+					throw Fault(string.Format("'{0}' is not a function.", name), start);
+				Enter();
+				_at++;
+				var args = new Expression[function.Arity];
+				for (int i = 0; i < function.Arity; i++)
+				{
+					if (i > 0)
+					{
+						SkipSpace();
+						if (Peek() != ',')
+							throw Fault(string.Format("'{0}' takes {1} values.", name, function.Arity), _at);
+						_at++;
+					}
+					args[i] = ParseAdditive();
+				}
+				SkipSpace();
+				if (Peek() != ')')
+					throw Fault(string.Format("'{0}' takes {1} values.", name, function.Arity), _at);
+				_at++;
+				Leave();
+				return Node(function.Build(args));
+			}
+
+			private Expression ParseReference(string name, string digits, int start)
+			{
+				if (name.Length != 1 || TypeLetters.IndexOf(char.ToLowerInvariant(name[0])) < 0)
+					throw Fault(string.Format("'{0}' is not a source.", name), start);
+				int index;
+				if (!int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out index) || index < 1)
+					throw Fault(string.Format("'{0}{1}' has no source number.", name, digits), start);
+				return Reference(new MapReference(char.ToLowerInvariant(name[0]), index), start);
+			}
+
+			/// <summary>Turns a source into a read of the slot its value will arrive in.</summary>
+			private Expression Reference(MapReference reference, int start)
+			{
+				var slot = References.IndexOf(reference);
+				if (slot < 0)
+				{
+					if (References.Count >= MaxReferences)
+						throw Fault(string.Format("More than {0} sources.", MaxReferences), start);
+					References.Add(reference);
+					slot = References.Count - 1;
+				}
+				// Resolved to an array slot here, once, so evaluation is an indexed read rather than a
+				// lookup by name on every poll.
+				return Node(Expression.Convert(
+					Expression.ArrayIndex(Values, Expression.Constant(slot)), typeof(double)));
+			}
+
+			private Expression Node(Expression expression)
+			{
+				if (++_nodes > MaxNodes)
+					throw Fault(string.Format("More than {0} operations.", MaxNodes), _at);
+				return expression;
+			}
+
+			// Depth is held by this counter rather than by catching an overflow, because an overflow
+			// cannot be caught: the process ends without running any handler.
+			private void Enter()
+			{
+				if (++_depth > MaxDepth)
+					throw Fault(string.Format("Nested deeper than {0} brackets.", MaxDepth), _at);
+			}
+
+			private void Leave()
+			{
+				_depth--;
+			}
+
+			private char Peek()
+			{
+				return _at < _text.Length ? _text[_at] : '\0';
+			}
+
+			private void SkipSpace()
+			{
+				while (_at < _text.Length && _text[_at] == ' ')
+					_at++;
+			}
+
+			private static FormatException Fault(string message, int at)
+			{
+				var ex = new FormatException(message);
+				ex.Data["pos"] = at;
+				return ex;
+			}
+		}
+
+		#endregion
+
+	}
+
+	/// <summary>One source an expression reads, named the way stored mappings name it.</summary>
+	public struct MapReference : IEquatable<MapReference>
+	{
+		public MapReference(char type, int index)
+		{
+			Type = type;
+			Index = index;
+		}
+
+		/// <summary>Source letter: a axis, b button, d d-pad button, h half slider, p d-pad, s slider, x half axis.</summary>
+		public readonly char Type;
+
+		/// <summary>One-based number of the source, as stored mappings count them.</summary>
+		public readonly int Index;
+
+		public bool Equals(MapReference other)
+		{
+			return Type == other.Type && Index == other.Index;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is MapReference && Equals((MapReference)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return Type * 397 ^ Index;
+		}
+
+		public override string ToString()
+		{
+			return string.Concat(Type, Index.ToString(CultureInfo.InvariantCulture));
+		}
+	}
+}

--- a/Engine/Common/MapExpressionHelp.cs
+++ b/Engine/Common/MapExpressionHelp.cs
@@ -1,0 +1,222 @@
+﻿using System.Collections.Generic;
+
+namespace x360ce.Engine
+{
+	/// <summary>
+	/// What the Help page shows about expressions: every operator, every function, every worked example.
+	/// </summary>
+	/// <remarks>
+	/// Held here rather than written into the page so the two cannot drift apart. A test compiles every
+	/// example and checks this catalogue against the parser in both directions, so a function that exists
+	/// without being listed, or a listing for something the parser will not accept, fails the build.
+	/// </remarks>
+	public static class MapExpressionHelp
+	{
+
+		/// <summary>Operators that combine two values.</summary>
+		public static readonly IList<MapExpressionOperator> BinaryOperators = new[]
+		{
+			new MapExpressionOperator("+", "Add", "=a1+a2", "Both sources move the same output."),
+			new MapExpressionOperator("-", "Subtract", "=a1-a2", "One source opposes the other, as two pedals on one axis."),
+			new MapExpressionOperator("*", "Multiply", "=a1*1.5", "Makes a source travel further for the same movement."),
+			new MapExpressionOperator("/", "Divide", "=a1/2", "Makes a source travel less, for finer control."),
+			new MapExpressionOperator("%", "Remainder", "=a1%0.25", "What is left after dividing, useful for repeating steps."),
+			new MapExpressionOperator("^", "Power", "=a1^2", "Raises to a power. 2^3^2 is 2^9, and -2^2 is -4."),
+		};
+
+		/// <summary>Operators that act on a single value.</summary>
+		public static readonly IList<MapExpressionOperator> UnaryOperators = new[]
+		{
+			new MapExpressionOperator("-", "Negate", "=-a1", "Reverses the direction of a source."),
+		};
+
+		/// <summary>Grouping, and the separator between the values a function takes.</summary>
+		public static readonly IList<MapExpressionOperator> Punctuation = new[]
+		{
+			new MapExpressionOperator("( )", "Group", "=(a1+a2)*0.5", "Work out the part in brackets first."),
+			new MapExpressionOperator(",", "Separate", "=min(a1,a2)", "Separates the values a function takes."),
+		};
+
+		/// <summary>Functions, with how many values each one takes.</summary>
+		public static readonly IList<MapExpressionFunction> Functions = new[]
+		{
+			new MapExpressionFunction("abs", 1, "Size of a value, ignoring its direction.", "=abs(a1)"),
+			new MapExpressionFunction("sign", 1, "Direction alone: -1, 0 or 1.", "=sign(a1)"),
+			new MapExpressionFunction("sqrt", 1, "Square root.", "=sqrt(a1)"),
+			new MapExpressionFunction("exp", 1, "The number e raised to this power.", "=exp(a1)-1"),
+			new MapExpressionFunction("floor", 1, "Rounds down to a whole number.", "=floor(a1*10)/10"),
+			new MapExpressionFunction("ceil", 1, "Rounds up to a whole number.", "=ceil(a1*10)/10"),
+			new MapExpressionFunction("round", 1, "Rounds to a whole number. A half goes to the even neighbour, so round(2.5) is 2 and round(3.5) is 4.", "=round(a1*10)/10"),
+			new MapExpressionFunction("sin", 1, "Sine. Angles are in degrees, so sin(90) is 1.", "=sin(a1*90)"),
+			new MapExpressionFunction("cos", 1, "Cosine. Angles are in degrees.", "=cos(a1*90)"),
+			new MapExpressionFunction("tan", 1, "Tangent. Angles are in degrees.", "=tan(a1*45)"),
+			new MapExpressionFunction("asin", 1, "The angle, in degrees, whose sine is this value.", "=asin(a1)/90"),
+			new MapExpressionFunction("acos", 1, "The angle, in degrees, whose cosine is this value.", "=acos(a1)/180"),
+			new MapExpressionFunction("atan", 1, "The angle, in degrees, whose tangent is this value.", "=atan(a1)/45"),
+			new MapExpressionFunction("min", 2, "The smaller of two values.", "=min(a1,0.8)"),
+			new MapExpressionFunction("max", 2, "The larger of two values.", "=max(a1,0)"),
+			new MapExpressionFunction("pow", 2, "The first value raised to the power of the second, the same as ^.", "=pow(a1,2)"),
+			new MapExpressionFunction("log", 2, "Logarithm of the first value in the base given by the second.", "=log(a1+1,2)"),
+			new MapExpressionFunction("clamp", 3, "Holds a value between a low and a high limit.", "=clamp(a1*2,0,1)"),
+			new MapExpressionFunction("deadzone", 2, "Ignores the first part of a movement, then stretches what is left over the full travel.", "=sign(a1)*deadzone(abs(a1),0.1)"),
+			new MapExpressionFunction("antideadzone", 2, "Lifts any movement above a floor, so a game that ignores small values still notices. Nothing is lifted at rest.", "=antideadzone(a1,0.15)"),
+			new MapExpressionFunction("curve", 2, "Bends the middle of the travel and leaves both ends alone, the same as the Sensitivity setting.", "=curve(a1,0.5)"),
+		};
+
+		/// <summary>Source letters an expression may read, and what each one means.</summary>
+		/// <remarks>
+		/// These are the letters stored mappings already use, with 'b' added for a button. A button is
+		/// stored as a bare number, which inside an expression cannot be told apart from the number
+		/// itself, so within an expression the letter is always required.
+		/// </remarks>
+		public static readonly IList<MapExpressionSource> Sources = new[]
+		{
+			new MapExpressionSource('a', "Axis", "-1 to 1",
+				"A stick or wheel that rests in the middle and moves both ways.", "a1"),
+			new MapExpressionSource('b', "Button", "0 or 1",
+				"A button: 0 while released, 1 while held.", "b1"),
+			new MapExpressionSource('s', "Slider", "0 to 1",
+				"A throttle, pedal or dial that rests at one end.", "s1"),
+			new MapExpressionSource('x', "Half axis", "0 to 1",
+				"One half of an axis on its own, so the two halves can drive different things.", "x1"),
+			new MapExpressionSource('h', "Half slider", "0 to 1",
+				"One half of a slider on its own.", "h1"),
+			new MapExpressionSource('p', "D-pad", "0 to 1",
+				"The hat switch read as a direction rather than as separate buttons.", "p1"),
+			new MapExpressionSource('d', "D-pad button", "0 or 1",
+				"One direction of the hat switch: 0 while released, 1 while held.", "d1"),
+		};
+
+		/// <summary>Worked examples, each written as the thing a player wanted.</summary>
+		public static readonly IList<MapExpressionExample> Examples = new[]
+		{
+			new MapExpressionExample("Aim", "Fine control near centre, full speed at the edge", "=a1*abs(a1)"),
+			new MapExpressionExample("Aim", "More sensitive everywhere", "=a1*1.5"),
+			new MapExpressionExample("Aim", "Less sensitive, for aiming through a scope", "=a1*0.5"),
+			new MapExpressionExample("Aim", "Walk slowly, run when the trigger is held", "=a1*(0.5+a2*0.5)"),
+			new MapExpressionExample("Aim", "Correct a stick that drifts off centre", "=a1-0.05"),
+			new MapExpressionExample("Triggers", "Full throttle before the trigger bottoms out", "=a1*1.5"),
+			new MapExpressionExample("Triggers", "A firmer press before anything happens", "=a1*a1"),
+			new MapExpressionExample("Wheels", "One pedal axis split into the accelerator", "=max(a1,0)"),
+			new MapExpressionExample("Wheels", "The same axis, its braking half", "=-min(a1,0)"),
+			new MapExpressionExample("Wheels", "Separate accelerator and brake onto one axis", "=a1-a2"),
+			new MapExpressionExample("Buttons", "Only while both buttons are held", "=b1*b2"),
+			new MapExpressionExample("Buttons", "While either button is held", "=max(b1,b2)"),
+			new MapExpressionExample("Buttons", "While the button is not held", "=1-b1"),
+			new MapExpressionExample("Buttons", "While one button is held but not the other", "=abs(b1-b2)"),
+			new MapExpressionExample("Buttons", "Full speed only while the button is held", "=a1*b1"),
+			new MapExpressionExample("Buttons", "Half speed until the button is held", "=a1*(0.5+b1*0.5)"),
+		};
+
+		/// <summary>
+		/// How the ordinary operators do the work of and, or and not, for sources that are 0 or 1.
+		/// </summary>
+		/// <remarks>
+		/// A button is 0 or 1, so logic needs no operators of its own: multiplying is and, taking the
+		/// larger is or, and subtracting from one is not. Adding words for these would be three more
+		/// things to learn, three more shapes in the grammar, and no new ability.
+		/// </remarks>
+		public static readonly IList<MapExpressionExample> ButtonLogic = new[]
+		{
+			new MapExpressionExample("Logic", "and, true only when both are held", "=b1*b2"),
+			new MapExpressionExample("Logic", "or, true when either is held", "=max(b1,b2)"),
+			new MapExpressionExample("Logic", "not, true while it is released", "=1-b1"),
+			new MapExpressionExample("Logic", "either but not both", "=abs(b1-b2)"),
+		};
+
+		/// <summary>Rules a person needs to know before writing one, in the order they need them.</summary>
+		public static readonly IList<string> Rules = new[]
+		{
+			"An expression starts with = and works out a number from other sources.",
+			"Sources are written as a letter and a number, the same way mappings are stored: a1 is axis 1, b2 is button 2.",
+			"The one source that is not a control is written as a word: now, the number of milliseconds since the program started. Divide it by 1000 for seconds, or by 60000 for minutes.",
+			"Values are already scaled for you: an axis runs from -1 to 1, a trigger or slider from 0 to 1, a button is 0 or 1.",
+			"The result is fitted to whatever it drives, so going past the limit is safe and simply reaches full travel.",
+			"Anything that is not a real number, such as dividing by zero, becomes 0.",
+			"Older versions of the program ignore expressions, so a configuration using one loses that mapping when opened in them.",
+			"A button is 0 or 1, so multiplying acts as and, taking the larger acts as or, and one minus it acts as not.",
+		};
+
+	}
+
+	/// <summary>One operator, as the Help page shows it.</summary>
+	public struct MapExpressionOperator
+	{
+		public MapExpressionOperator(string symbol, string name, string example, string meaning)
+		{
+			Symbol = symbol;
+			Name = name;
+			Example = example;
+			Meaning = meaning;
+		}
+
+		public readonly string Symbol;
+		public readonly string Name;
+		public readonly string Example;
+		public readonly string Meaning;
+	}
+
+	/// <summary>One function, as the Help page shows it.</summary>
+	public struct MapExpressionFunction
+	{
+		public MapExpressionFunction(string name, int arity, string meaning, string example)
+		{
+			Name = name;
+			Arity = arity;
+			Meaning = meaning;
+			Example = example;
+		}
+
+		public readonly string Name;
+
+		/// <summary>How many values the function takes.</summary>
+		public readonly int Arity;
+
+		public readonly string Meaning;
+		public readonly string Example;
+	}
+
+	/// <summary>One kind of source an expression may read.</summary>
+	public struct MapExpressionSource
+	{
+		public MapExpressionSource(char letter, string name, string range, string meaning, string example)
+		{
+			Letter = letter;
+			Name = name;
+			Range = range;
+			Meaning = meaning;
+			Example = example;
+		}
+
+		/// <summary>The letter that names this kind of source inside an expression.</summary>
+		public readonly char Letter;
+
+		public readonly string Name;
+
+		/// <summary>The value range this source arrives as, once scaled.</summary>
+		public readonly string Range;
+
+		/// <summary>What the source is, for somebody who has not met the word before.</summary>
+		public readonly string Meaning;
+
+		public readonly string Example;
+	}
+
+	/// <summary>One worked example, written as the thing a player wanted.</summary>
+	public struct MapExpressionExample
+	{
+		public MapExpressionExample(string group, string goal, string expression)
+		{
+			Group = group;
+			Goal = goal;
+			Expression = expression;
+		}
+
+		public readonly string Group;
+
+		/// <summary>What the player wanted, not what the operator does.</summary>
+		public readonly string Goal;
+
+		public readonly string Expression;
+	}
+}

--- a/Engine/Common/MapExpressionSeed.cs
+++ b/Engine/Common/MapExpressionSeed.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Globalization;
+
+namespace x360ce.Engine
+{
+	/// <summary>
+	/// Writes a row's existing dead zone, anti dead zone and sensitivity out as an expression.
+	/// </summary>
+	/// <remarks>
+	/// An expression replaces those three settings for its row rather than being layered on top of
+	/// them. Layering has no defensible order, and the two work in different units: the settings are in
+	/// the destination's units and an expression is in normalised ones.
+	///
+	/// Replacing them would lose somebody's tuning at the moment they switch the row over, so switching
+	/// over writes the tuning out as the formula that produces it. Nothing is lost, the result is
+	/// unchanged until they edit it, and they are shown their own configuration written in the syntax
+	/// they are about to use, which teaches it better than any help page.
+	/// </remarks>
+	public static class MapExpressionSeed
+	{
+
+		/// <summary>Largest value a thumb stick reports, and the unit its dead zones are given in.</summary>
+		public const float ThumbMax = 32767f;
+
+		/// <summary>Largest value a trigger reports, and the unit its dead zones are given in.</summary>
+		public const float TriggerMax = 255f;
+
+		/// <summary>
+		/// A stored mapping written the way a formula names the same control.
+		/// </summary>
+		/// <param name="stored">The mapping as it is kept, such as "a1", "x3" or "1".</param>
+		/// <returns>The same control as a formula names it, or null when it has no plain form.</returns>
+		/// <remarks>
+		/// The two notations disagree about buttons and the disagreement is silent. Storage writes a
+		/// button as a bare number, so button one is kept as "1". Inside a formula "1" is the number
+		/// one, which is a value that never changes rather than a button anybody can press. Handing a
+		/// stored button straight to a formula therefore produces something that reads as sensible,
+		/// compiles, runs, and is not the control the person chose.
+		///
+		/// A stick pushed the other way is stored as a negative number and becomes a minus sign, which
+		/// is exactly what it means. Nothing else has a plain opposite: half of an axis read backwards,
+		/// or a button counted as released, cannot be said with the sources a formula has. Those give
+		/// nothing back rather than something close, because a formula that is nearly right is worse
+		/// than no formula at all.
+		/// </remarks>
+		public static string AsExpressionSource(string stored)
+		{
+			if (string.IsNullOrEmpty(stored))
+				return null;
+			var text = stored.Trim();
+			if (text.Length == 0 || MapExpression.IsExpression(text))
+				return null;
+			// A letter at the front names the kind. Without one it is a button, which is stored bare.
+			var letter = char.IsLetter(text[0]) ? char.ToLowerInvariant(text[0]) : 'b';
+			var digits = char.IsLetter(text[0]) ? text.Substring(1) : text;
+			if (MapExpression.SourceLetters.IndexOf(letter) < 0)
+				return null;
+			int index;
+			if (!int.TryParse(digits, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out index))
+				return null;
+			if (index == 0)
+				return null;
+			var source = letter.ToString() + Math.Abs(index).ToString(CultureInfo.InvariantCulture);
+			if (index > 0)
+				return source;
+			// Only a whole axis has a plain opposite: the same stick pushed the other way.
+			return letter == 'a' ? "-" + source : null;
+		}
+
+		/// <summary>
+		/// The expression that reproduces a row's current settings, including the leading prefix.
+		/// </summary>
+		/// <param name="source">Source the row reads, written as it is stored, such as "a1".</param>
+		/// <param name="deadZone">Dead zone in the destination's units.</param>
+		/// <param name="antiDeadZone">Anti dead zone in the destination's units.</param>
+		/// <param name="linear">Sensitivity, as the interface stores it, -100 to 100.</param>
+		/// <param name="destinationMax">
+		/// <see cref="ThumbMax"/> or <see cref="TriggerMax"/>, whichever the row drives.
+		/// </param>
+		/// <remarks>
+		/// The shortest expression that produces the same result is written, so a row with nothing set
+		/// seeds as the bare source rather than as arithmetic that cancels itself out. A person opening
+		/// a formula for the first time should see something they can read.
+		/// </remarks>
+		public static string FromSettings(string source, float deadZone, float antiDeadZone, float linear, float destinationMax)
+		{
+			if (string.IsNullOrEmpty(source))
+				return MapExpression.Prefix;
+			if (destinationMax <= 0f)
+				destinationMax = ThumbMax;
+			var dead = Clamp01(deadZone / destinationMax);
+			var anti = Clamp01(antiDeadZone / destinationMax);
+			var curve = Math.Max(-1f, Math.Min(1f, linear / 100f));
+			// Nothing set, so the value passes through and the formula says exactly that.
+			if (dead <= 0f && anti <= 0f && curve == 0f)
+				return MapExpression.Prefix + source;
+			// Everything below works on the distance from the centre, and the direction is put back at
+			// the end. Without that a dead zone would only work one way.
+			var size = "abs(" + source + ")";
+			// Named rather than spelled out. The same three steps written as arithmetic came to over
+			// three hundred characters for a fully tuned row, because each part had to be repeated for
+			// every place it appeared - too long to store, and far too long to learn anything from.
+			if (dead > 0f)
+				size = "deadzone(" + size + "," + N(dead) + ")";
+			if (curve != 0f)
+				size = "curve(" + size + "," + N(curve) + ")";
+			if (anti > 0f)
+				size = "antideadzone(" + size + "," + N(anti) + ")";
+			var full = MapExpression.Prefix + "sign(" + source + ")*" + size;
+			// A row's settings written out in full do not fit in sixteen characters, which is what a
+			// mapping is stored in until the column is widened. Rather than offer something that
+			// cannot be saved, the plain source is given: switching the row over then changes nothing
+			// and loses nothing, because the settings it came from are still there to be read.
+			return full.Length <= MapExpression.MaxLength
+				? full
+				: MapExpression.Prefix + source;
+		}
+
+		/// <summary>
+		/// A number as the grammar reads it: a dot for the decimal mark, and no trailing noise.
+		/// </summary>
+		private static string N(float value)
+		{
+			var text = Math.Round(value, 4).ToString("0.####", CultureInfo.InvariantCulture);
+			return text.Length == 0 ? "0" : text;
+		}
+
+		private static float Clamp01(float value)
+		{
+			if (float.IsNaN(value) || value < 0f)
+				return 0f;
+			// A dead zone of the whole travel would leave nothing to stretch, and dividing by what is
+			// left would not be a number.
+			return value > 0.99f ? 0.99f : value;
+		}
+
+	}
+}

--- a/Engine/Common/MapExpressionUnits.cs
+++ b/Engine/Common/MapExpressionUnits.cs
@@ -1,0 +1,213 @@
+﻿using System;
+
+namespace x360ce.Engine
+{
+	/// <summary>
+	/// Translates between the units a formula is written in and the units a device reports and
+	/// expects.
+	/// </summary>
+	/// <remarks>
+	/// A formula is written in plain units, so that somebody writing one is thinking about the
+	/// control rather than about how it happens to be stored. A stick reads -1 to 1 and rests at 0.
+	/// A pedal or trigger reads 0 to 1 and rests at 0. A button reads 0 or 1. Everything a formula
+	/// produces is in the same units, so the result can be applied to any destination.
+	///
+	/// DirectInput reports an axis as a whole number from 0 to 65535 with the middle at 32767, which
+	/// is a detail of the interface rather than anything a player should have to know. Turning it
+	/// into the plain units happens here, once, in one place.
+	/// </remarks>
+	public static class MapExpressionUnits
+	{
+
+		/// <summary>Largest value DirectInput reports for an axis or a slider.</summary>
+		public const int RawMax = ushort.MaxValue;
+
+		/// <summary>The middle of an axis, where a stick sits when nobody is touching it.</summary>
+		public const int RawCentre = 32767;
+
+		/// <summary>
+		/// Fills the values a compiled formula expects, in the order it expects them.
+		/// </summary>
+		/// <param name="expression">The formula, whose references give the order.</param>
+		/// <param name="state">The controller's current state.</param>
+		/// <param name="values">Buffer to fill. Must hold at least one value per reference.</param>
+		/// <returns>False when nothing could be read, in which case the buffer is untouched.</returns>
+		/// <param name="isThumb">
+		/// True when the answer drives a stick, false when it drives a trigger or a button.
+		/// </param>
+		public static bool TryFill(MapExpression expression, CustomDiState state, float[] values, bool isThumb)
+		{
+			if (expression == null || state == null || values == null)
+				return false;
+			var references = expression.References;
+			if (values.Length < references.Count)
+				return false;
+			for (int i = 0; i < references.Count; i++)
+				values[i] = Read(references[i], state, isThumb);
+			return true;
+		}
+
+		/// <summary>One control's value, in the units a formula is written in.</summary>
+		/// <remarks>
+		/// A control the device does not have reads as nought rather than failing. A formula naming
+		/// axis nine on a device with four is describing something that is simply not there, and a
+		/// control that is not there is not being moved.
+		/// </remarks>
+		/// <param name="isThumb">
+		/// True when the answer drives a stick, false when it drives a trigger or a button.
+		///
+		/// Only an axis is read differently by what it drives, and that is not this program inventing
+		/// a rule: it is the rule the program already follows everywhere else. The same axis handed to
+		/// a trigger covers the whole of the trigger's travel, and handed to a stick covers both
+		/// directions from the middle. A trigger rests at one end and a stick rests in the middle, so
+		/// there is no single reading that is right for both.
+		///
+		/// Reading a trigger as though it rested in the middle is what made "=a5*2" hold the trigger
+		/// fully down while nobody was touching it: at rest it read minus one, which doubled to minus
+		/// two, which is past the end.
+		/// </param>
+		public static float Read(MapReference reference, CustomDiState state, bool isThumb)
+		{
+			if (state == null)
+				return 0f;
+			var index = reference.Index - 1;
+			if (index < 0)
+				return 0f;
+			switch (reference.Type)
+			{
+				case 'a':
+					// For a stick the middle becomes nought and the ends become -1 and 1. For a trigger
+					// the whole travel becomes nought to one, because that is where a trigger rests.
+					return index < state.Axis.Length
+						? (isThumb ? Centred(state.Axis[index]) : Whole(state.Axis[index]))
+						: 0f;
+				case 'x':
+					// The same stick read as one half, so each half can drive something different.
+					return index < state.Axis.Length
+						? Positive(state.Axis[index])
+						: 0f;
+				case 's':
+					// A pedal or throttle: rests at one end, so nought there and one at the other.
+					return index < state.Sliders.Length
+						? Whole(state.Sliders[index])
+						: 0f;
+				case 'h':
+					return index < state.Sliders.Length
+						? Positive(state.Sliders[index])
+						: 0f;
+				case 'b':
+					return index < state.Buttons.Length && state.Buttons[index]
+						? 1f
+						: 0f;
+				case 'd':
+					// A hat direction, which arrives already turned into a button.
+					return index < state.Buttons.Length && state.Buttons[index]
+						? 1f
+						: 0f;
+				case 'p':
+					return index < state.Buttons.Length && state.Buttons[index]
+						? 1f
+						: 0f;
+				default:
+					// The clock, which is not a control and has no index.
+					return reference.Type == MapExpression.TimeType
+						? Milliseconds()
+						: 0f;
+			}
+		}
+
+		/// <summary>
+		/// How long the program has been running, in whole milliseconds.
+		/// </summary>
+		/// <remarks>
+		/// Given as a plain count so that a person can divide it into whatever they need: by a
+		/// thousand for seconds, by sixty thousand for minutes.
+		///
+		/// Counted from when the program started rather than from a date, because a formula only ever
+		/// cares how much time has passed. A count of milliseconds since a date is far too large a
+		/// number to hold in the values a formula works in, and would arrive already rounded to
+		/// something coarser than a second.
+		///
+		/// The values a formula works in hold whole numbers exactly up to about sixteen million, which
+		/// is a little under five hours. After that the count is still correct but stops being exact to
+		/// the millisecond, and anything oscillating quickly will slow its step. Something repeating on
+		/// a minute or an hour is unaffected.
+		/// </remarks>
+		public static float Milliseconds()
+		{
+			return (float)Clock.Elapsed.TotalMilliseconds;
+		}
+
+		/// <summary>Started once, when the program first asks the time of anything.</summary>
+		private static readonly System.Diagnostics.Stopwatch Clock = System.Diagnostics.Stopwatch.StartNew();
+
+		/// <summary>Raw 0 to 65535 as -1 to 1, with the middle at nought.</summary>
+		private static float Centred(int raw)
+		{
+			return Clamp((raw - RawCentre) / (float)RawCentre, -1f, 1f);
+		}
+
+		/// <summary>Raw 0 to 65535 as 0 to 1.</summary>
+		private static float Whole(int raw)
+		{
+			return Clamp(raw / (float)RawMax, 0f, 1f);
+		}
+
+		/// <summary>The upper half of a raw range as 0 to 1, with the lower half resting at nought.</summary>
+		private static float Positive(int raw)
+		{
+			return raw <= RawCentre
+				? 0f
+				: Clamp((raw - RawCentre) / (float)RawCentre, 0f, 1f);
+		}
+
+		#region Destinations
+
+		/// <summary>A formula's answer as a trigger position, which only travels one way.</summary>
+		/// <remarks>
+		/// The sign is dropped rather than clamped away, so a formula written for a stick still does
+		/// something sensible when somebody puts it on a trigger.
+		/// </remarks>
+		public static byte ToTrigger(float value)
+		{
+			if (float.IsNaN(value))
+				return 0;
+			var size = value < 0f ? -value : value;
+			// Rounded, not cut short. Half of a trigger's travel doubled is a whole one, and cutting
+			// short reports that as one step less than full, for ever.
+			return size >= 1f ? byte.MaxValue : (byte)Math.Round(size * byte.MaxValue, MidpointRounding.AwayFromZero);
+		}
+
+		/// <summary>A formula's answer as a stick position, which travels both ways.</summary>
+		public static short ToThumb(float value)
+		{
+			if (float.IsNaN(value))
+				return 0;
+			if (value >= 1f)
+				return short.MaxValue;
+			if (value <= -1f)
+				return short.MinValue;
+			return (short)Math.Round(value * short.MaxValue, MidpointRounding.AwayFromZero);
+		}
+
+		/// <summary>Whether a formula's answer counts as a button being held.</summary>
+		/// <remarks>
+		/// Half way is the point, which is the obvious place and makes a formula that answers 0 or 1
+		/// behave exactly as it reads.
+		/// </remarks>
+		public static bool IsPressed(float value)
+		{
+			return value >= 0.5f;
+		}
+
+		#endregion
+
+		private static float Clamp(float value, float low, float high)
+		{
+			if (float.IsNaN(value))
+				return low < 0f ? 0f : low;
+			return value < low ? low : value > high ? high : value;
+		}
+
+	}
+}

--- a/Engine/Data/PadSetting.cs
+++ b/Engine/Data/PadSetting.cs
@@ -26,7 +26,14 @@ namespace x360ce.Engine.Data
 			{
 				lock (MapsLock)
 				{
-					if (MapsChanged || true)
+					// Rebuilt only when something actually changed. Every property of this object reports
+					// its own change, and that is what sets the flag, so the answer here cannot go stale.
+					//
+					// This used to rebuild every time it was asked, which is once per poll, about a
+					// thousand times a second: thirty thousand of these objects a second, each reading
+					// its text again, and all of them thrown away. It was the largest single cost the
+					// program had while sitting doing nothing.
+					if (MapsChanged)
 					{
 						var maps = new List<Map>();
 						// Add buttons.

--- a/Engine/Maps/Map.cs
+++ b/Engine/Maps/Map.cs
@@ -46,6 +46,16 @@ namespace x360ce.Engine
 
 		void Load(string value)
 		{
+			// A formula is compiled once here, where a mapping is read, rather than every time the
+			// controller is polled. What follows describes a single control and cannot describe a
+			// formula, so the two are kept apart and only one of them is ever set.
+			if (MapExpression.IsExpression(value))
+			{
+				string error;
+				int position;
+				MapExpression.TryParse(value, out Expression, out error, out position);
+				return;
+			}
 			SettingsConverter.TryParseIniValue(value, out Type, out Index);
 			IsButton = SettingsConverter.IsButton(Type);
 			IsAxis = SettingsConverter.IsAxis(Type);
@@ -53,6 +63,16 @@ namespace x360ce.Engine
 			IsHalf = SettingsConverter.IsHalf(Type);
 			IsInverted = SettingsConverter.IsInverted(Type);
 		}
+
+		/// <summary>
+		/// The formula this row is driven by, or null when it is mapped to a single control.
+		/// </summary>
+		/// <remarks>
+		/// Null also covers a formula that would not compile. A mapping that cannot be read does
+		/// nothing, which is the same as one that was never set, and is what stops a mistyped formula
+		/// from taking a controller down mid-game.
+		/// </remarks>
+		public MapExpression Expression;
 
 		// Source Parameters.
 		public MapType Type;

--- a/Engine/x360ce.Engine.csproj
+++ b/Engine/x360ce.Engine.csproj
@@ -133,6 +133,10 @@
     <Compile Include="Common\CloudMessage.cs" />
     <Compile Include="Common\CloudHelper.Security.cs" />
     <Compile Include="Common\ConvertHelper.cs" />
+    <Compile Include="Common\MapExpression.cs" />
+    <Compile Include="Common\MapExpressionUnits.cs" />
+    <Compile Include="Common\MapExpressionHelp.cs" />
+    <Compile Include="Common\MapExpressionSeed.cs" />
     <Compile Include="Common\CustomDiHelper.cs" />
     <Compile Include="Common\CustomDiState.cs" />
     <Compile Include="Common\CustomDiUpdate.cs" />

--- a/Native/x360ce/Config.cpp
+++ b/Native/x360ce/Config.cpp
@@ -189,7 +189,7 @@ void Config::ParsePrefix(const std::string& input, MappingType* pMappingType, s8
 	}
 }
 
-void Config::ReadConfig()
+void Config::ReadConfig(std::vector<std::shared_ptr<ControllerBase>>& controllers)
 {
 	IniFile ini;
 	std::string inipath("x360ce.ini");
@@ -265,19 +265,15 @@ void Config::ReadConfig()
 			controller->m_combined = true;
 			controller->m_combinedIndex = combinedIndex;
 
-			// Get Controllers
-			// auto controllers = ControllerManager::Get().GetControllers();
-
 			// Attempt to find an existing combiner for the index
-			// auto found = std::find_if(controllers.begin(), controllers.end(), 
-			auto found = std::find_if(ControllerManager::Get().GetControllers().begin(), ControllerManager::Get().GetControllers().end(),
+			auto found = std::find_if(controllers.begin(), controllers.end(),
 				[combinedIndex](std::shared_ptr<ControllerBase> c)
 			{
 				return (c->m_combined) && (c->m_combinedIndex == combinedIndex);
 			});
 
 			// If not found, create it
-			if (found == ControllerManager::Get().GetControllers().end())
+			if (found == controllers.end())
 			{
 				// Create combiner
 				std::shared_ptr<ControllerCombiner> combiner(new ControllerCombiner(combinedIndex));
@@ -289,7 +285,7 @@ void Config::ReadConfig()
 				combiner->GetControllers().push_back(controller);
 
 				// Add the combiner to the controllers collection
-				ControllerManager::Get().GetControllers().push_back(combiner);
+				controllers.push_back(combiner);
 			}
 			else
 			{
@@ -303,7 +299,7 @@ void Config::ReadConfig()
 		else
 		{
 			// Not a combined device. Just add like normal.
-			ControllerManager::Get().GetControllers().push_back(controller);
+			controllers.push_back(controller);
 		}
 	}
 }

--- a/Native/x360ce/Config.h
+++ b/Native/x360ce/Config.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 class Controller;
+class ControllerBase;
 
 class Config
 {
@@ -122,7 +126,7 @@ public:
 	static const char* const triggerDZNames[];
 	static const char* const triggerBNames[];
 
-	void ReadConfig();
+	void ReadConfig(std::vector<std::shared_ptr<ControllerBase>>& controllers);
 
 private:
 	bool ReadPadConfig(Controller* pController, const std::string& section, IniFile* pIniFile);

--- a/Native/x360ce/ControllerManager.h
+++ b/Native/x360ce/ControllerManager.h
@@ -28,7 +28,9 @@ public:
 		if (GetWindowsVersionName(&windows_name))
 			PrintLog("OS: \"%s\"", windows_name.c_str());
 
-		m_config.ReadConfig();
+		// Pass the list rather than letting ReadConfig reach back through Get(),
+		// which would re-enter the static initialisation still running on this thread.
+		m_config.ReadConfig(m_controllers);
 
 		bool bHookDI = InputHookManager::Get().GetInputHook().GetState(InputHook::HOOK_DI);
 		if (bHookDI) InputHookManager::Get().GetInputHook().DisableHook(InputHook::HOOK_DI);

--- a/Native/x360ce/dllmain.cpp
+++ b/Native/x360ce/dllmain.cpp
@@ -48,8 +48,9 @@ extern "C" VOID WINAPI Reset()
 
 	// Only x360ce.App will call this so InputHook is not required, disable it.
 	InputHookManager::Get().GetInputHook().Shutdown();
-	ControllerManager::Get().GetControllers().clear();
-	ControllerManager::Get().GetConfig().ReadConfig();
+	auto& manager = ControllerManager::Get();
+	manager.GetControllers().clear();
+	manager.GetConfig().ReadConfig(manager.GetControllers());
 }
 
 

--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,10 @@ slider 1. An axis reads from -1 to 1 when it drives a stick and from 0 to 1 when
 trigger, matching what the row already did. `now` reads the milliseconds since the program
 started; divide it by 1000 for seconds or by 60000 for minutes.
 
+The formula takes effect as it is typed, so a number can be adjusted and the difference felt at
+once. The `fx` button says whether it works: green while the formula is understood and driving
+the row, red while it is written down and not. Point at a red one to read what is wrong with it.
+
 A formula replaces the dead zone, anti dead zone and sensitivity for its row rather than being
 applied on top of them.
 

--- a/README.MD
+++ b/README.MD
@@ -6,11 +6,35 @@ Every signed build is published on the [Releases page](https://github.com/x360ce
 
 # Download v4.x
 
-Digitally Signed Application v4.18.23.0 and Virtual Gamepad Emulation Bus 1.16.112.0
+Digitally Signed Application v4.18.35.0 and Virtual Gamepad Emulation Bus 1.16.112.0
 
 Download `x360ce.zip` from the [latest v4 release](https://github.com/x360ce/x360ce/releases) - for All games
 
 Note: version 4.x use Virtual Gamepad Emulation. Instructions can be found here: https://github.com/x360ce/x360ce/wiki/Beta-Testing
+
+## Mapping formulas (v4.x)
+
+A mapping row can hold a formula instead of a single control. Press the small `fx` button beside
+the row and type one, starting with `=`.
+
+    =a5*2        double the trigger, so it reaches full at a half press
+    =a1*0.5      halve the stick, for aiming through a scope
+    =a1*abs(a1)  fine control near the centre, full speed at the edge
+    =max(a1,0)   use only one half of a pedal axis
+
+Sources are written the way mappings are stored: `a1` is axis 1, `b2` is button 2, `s1` is
+slider 1. An axis reads from -1 to 1 when it drives a stick and from 0 to 1 when it drives a
+trigger, matching what the row already did. `now` reads the milliseconds since the program
+started; divide it by 1000 for seconds or by 60000 for minutes.
+
+A formula replaces the dead zone, anti dead zone and sensitivity for its row rather than being
+applied on top of them.
+
+**A formula is limited to 16 characters**, which is the width a mapping is stored in. That is
+enough for the examples above and not enough to write a dead zone or a curve out in full. The
+limit is raised in a later release.
+
+The Help page lists every operator, function and source.
 
 # Download v3.x
 

--- a/Tests/Common/DInput/VirtualDriverInstallerTest.cs
+++ b/Tests/Common/DInput/VirtualDriverInstallerTest.cs
@@ -1,0 +1,154 @@
+// @under-test: App.v4/Common/DInput/VirtualDriverInstaller.cs
+// @area: devices   @layer: unit
+using JocysCom.ClassLibrary.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using x360ce.App.DInput;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// Telling a pad this program created from a controller somebody is holding.
+	/// </summary>
+	/// <remarks>
+	/// The shapes below were measured on a machine that had accumulated fifty two leftover pads. The
+	/// program listed every one of them as real hardware, put them back after each restart, and filled
+	/// all four XInput places, so a player saw a controller moving on its own.
+	///
+	/// The cause was that a pad was recognised by walking up its parent chain to the virtual bus. That
+	/// works while the bus still holds the pad. It fails for a pad left behind, because the node its
+	/// chain points at has already gone, so the walk arrives nowhere and the pad is called real.
+	/// </remarks>
+	[TestClass]
+	public class VirtualDriverInstallerTest
+	{
+
+		private const string ViGEmBusId = @"ROOT\SYSTEM\0001";
+
+		private static DeviceInfo Device(string id, string parentId, string hardwareIds)
+		{
+			return new DeviceInfo { DeviceId = id, ParentDeviceId = parentId, HardwareIds = hardwareIds };
+		}
+
+		private static Dictionary<string, DeviceInfo> World(params DeviceInfo[] devices)
+		{
+			return VirtualDriverInstaller.IndexById(devices);
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("A pad still held by the virtual bus is recognised")]
+		public void A_pad_the_bus_still_holds_is_ours()
+		{
+			var bus = Device(ViGEmBusId, null, @"Root\ViGEmBus");
+			var stem = Device(@"USB\VID_045E&PID_028E\1&79F5D87&0&60", ViGEmBusId, @"USB\VID_045E&PID_028E");
+			var pad = Device(@"USB\VID_045E&PID_028E&IG_0F\2&14BB91BF&0&0F", stem.DeviceId, @"USB\VID_045E&PID_028E&IG_0F");
+			Assert.IsTrue(VirtualDriverInstaller.IsVirtualPad(pad, World(bus, stem, pad)));
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("A pad left behind, whose parent has gone, is recognised as ours")]
+		public void A_pad_left_behind_is_ours()
+		{
+			// Exactly what was measured: the pad names a parent that is no longer anywhere in the
+			// system, because removing the node above it did not take its children with it.
+			var pad = Device(@"USB\VID_045E&PID_028E&IG_0F\2&14BB91BF&0&0F",
+				@"USB\VID_045E&PID_028E\1&79f5d87&0&06", @"USB\VID_045E&PID_028E&IG_0F");
+			Assert.IsTrue(VirtualDriverInstaller.IsVirtualPad(pad, World(pad)),
+				"A pad whose parent has gone was called real hardware. That is what put fifty of " +
+				"them in the device list and put them back after every restart.");
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("A pad created moments ago, with no hardware list yet, is still recognised")]
+		public void A_pad_with_no_hardware_list_yet_is_still_ours()
+		{
+			// Measured: three pads leaked during testing arrived with an empty hardware list and were
+			// let through, while older ones were caught. The marker was in the identifier all along.
+			var pad = Device(@"HID\VID_045E&PID_028E&IG_39\3&96A9016&0&0000",
+				@"USB\VID_045E&PID_028E&IG_39\2&1B68A5EB&0&39", "");
+			Assert.IsTrue(VirtualDriverInstaller.IsVirtualPad(pad, World(pad)),
+				"A pad whose hardware list has not been filled in yet was called real hardware.");
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("The bus is never mistaken for one of the pads it makes")]
+		public void The_bus_is_not_one_of_its_own_pads()
+		{
+			// The list this feeds exists so that everything on it can be deleted. Putting the bus on
+			// it removes the virtual driver, and with it the ability to emulate anything at all.
+			var bus = Device(ViGEmBusId, null, @"Root\ViGEmBus");
+			Assert.IsFalse(VirtualDriverInstaller.IsVirtualPad(bus, World(bus)),
+				"The virtual bus was listed as a leftover pad. Deleting that list would uninstall it.");
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("A controller somebody is holding is never taken for one of ours")]
+		public void A_real_controller_is_not_ours()
+		{
+			// A real device reaches the top of the tree through nodes that all exist. Measured at
+			// between five and nine steps for every real device on the machine in question.
+			var root = Device(@"HTREE\ROOT\0", null, null);
+			var hub = Device(@"USB\ROOT_HUB30\4&2C4A1B1&0", root.DeviceId, @"USB\ROOT_HUB30");
+			var pad = Device(@"USB\VID_054C&PID_0CE6\7&186C5E73&1&4", hub.DeviceId, @"USB\VID_054C&PID_0CE6");
+			Assert.IsFalse(VirtualDriverInstaller.IsVirtualPad(pad, World(root, hub, pad)));
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("A broken chain only counts against a device carrying the XInput marker")]
+		public void A_broken_chain_alone_does_not_hide_somebody_s_wheel()
+		{
+			// This is the guarantee that makes the rule safe to apply during a scan. A wheel or a
+			// stick with an odd chain stays visible; only the shape this program itself produces can
+			// be judged missing. Hiding somebody's own controller would be a worse fault than
+			// showing a leftover.
+			var wheel = Device(@"USB\VID_046D&PID_C29B\1&2A3B4C5D", @"USB\SOMETHING_GONE\0", @"USB\VID_046D&PID_C29B");
+			Assert.IsFalse(VirtualDriverInstaller.IsVirtualPad(wheel, World(wheel)),
+				"A device with no XInput marker was hidden because its chain was broken.");
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("A chain that leads back on itself ends the walk instead of the window")]
+		public void A_chain_that_loops_does_not_hang()
+		{
+			// The walk this replaces had nothing to stop it. Two nodes naming each other as parent
+			// would have held the interface thread for as long as the program ran.
+			var a = Device("A", "B", @"USB\VID_045E&PID_028E&IG_01");
+			var b = Device("B", "A", @"USB\VID_045E&PID_028E");
+			var world = World(a, b);
+			var finished = false;
+			var task = System.Threading.Tasks.Task.Run(() =>
+			{
+				VirtualDriverInstaller.IsVirtualPad(a, world);
+				finished = true;
+			});
+			Assert.IsTrue(task.Wait(2000) && finished, "The walk did not come back. A loop in the tree hangs the program.");
+		}
+
+		[TestMethod, TestCategory("devices"), TestCategory("critical")]
+		[Description("Installing over an existing bus updates it rather than adding a second one")]
+		public void Installing_over_an_existing_bus_does_not_add_another()
+		{
+			// Measured: this computer ended up with two buses because install was run twice, and the
+			// second run made a second bus rather than touching the first. Nothing looks wrong when
+			// it happens, which is why it has to be held here.
+			Assert.AreEqual("install", VirtualDriverInstaller.GetInstallCommand(0),
+				"With no bus present there is nothing to update, so one has to be made.");
+			Assert.AreEqual("update", VirtualDriverInstaller.GetInstallCommand(1),
+				"A bus is already there. Installing again would leave two.");
+			Assert.AreEqual("update", VirtualDriverInstaller.GetInstallCommand(5),
+				"Several are already there. Installing again would make it six.");
+		}
+
+		[TestMethod, TestCategory("devices")]
+		[Description("The XInput marker is read the way Microsoft documents it")]
+		public void The_marker_is_read_case_insensitively()
+		{
+			Assert.IsTrue(VirtualDriverInstaller.CarriesInputGroup(@"USB\VID_045E&PID_028E&IG_0F"));
+			Assert.IsTrue(VirtualDriverInstaller.CarriesInputGroup(@"usb\vid_045e&pid_028e&ig_0f"));
+			Assert.IsFalse(VirtualDriverInstaller.CarriesInputGroup(@"USB\VID_054C&PID_0CE6"));
+			Assert.IsFalse(VirtualDriverInstaller.CarriesInputGroup(null));
+			Assert.IsFalse(VirtualDriverInstaller.CarriesInputGroup(""));
+		}
+
+	}
+}

--- a/Tests/Common/EmbeddedSymbolsTest.cs
+++ b/Tests/Common/EmbeddedSymbolsTest.cs
@@ -45,19 +45,44 @@ namespace x360ce.Tests
 		}
 
 		[TestMethod, TestCategory("diagnostics")]
-		[Description("Every program asks the runtime to read the symbols it carries")]
-		public void Programs_ask_for_the_symbols_they_carry()
+		[Description("Every program asks the runtime for what it needs, from code rather than a file")]
+		public void Programs_ask_for_what_they_need_in_code()
 		{
-			// One switch, easy to leave out of a new configuration file, and nothing fails when
-			// it is missing except that every crash report stops naming lines.
-			foreach (var config in new[] { @"App.v4\app.config", @"App.v3\app.config", @"Tests\app.config" })
+			// These were once set in app.config, which put them in a file the build writes beside
+			// the program. The programs ship as one file, so that file never reaches anyone who
+			// downloads them, and every switch silently did nothing. Nothing failed: the tests ran
+			// against a build folder, where the file is present, and passed while the shipped
+			// program had no symbols and no accessibility at all.
+			var required = new[]
+			{
+				"Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces",
+				"Switch.UseLegacyAccessibilityFeatures",
+			};
+			foreach (var program in new[] { @"App.v4\Program.cs", @"App.v3\Program.cs" })
+			{
+				var path = Path.Combine(Ui.RepoRoot.FullName, program);
+				Assert.IsTrue(File.Exists(path), program + " is missing.");
+				var code = File.ReadAllText(path);
+				foreach (var name in required)
+				{
+					// Checked with Contains rather than StringAssert, which prints the whole file
+					// when it fails and buries the one line that matters.
+					Assert.IsTrue(code.Contains("AppContext.SetSwitch(\"" + name + "\", false)"),
+						program + " does not ask for " + name + " at start-up, so it will do nothing "
+						+ "for anyone running the shipped single file.");
+				}
+			}
+
+			// One place only. A switch in both a file and the code is two answers to one question,
+			// and the file is the one that will be believed while being absent where it matters.
+			foreach (var config in new[] { @"App.v4\app.config", @"App.v3\app.config" })
 			{
 				var path = Path.Combine(Ui.RepoRoot.FullName, config);
-				Assert.IsTrue(File.Exists(path), config + " is missing.");
-				StringAssert.Contains(File.ReadAllText(path),
-					"Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false",
-					config + " does not ask the runtime to read the symbols carried inside its "
-					+ "binaries, so its crash reports will name no line.");
+				if (!File.Exists(path))
+					continue;
+				Assert.IsFalse(File.ReadAllText(path).Contains("AppContextSwitchOverrides"),
+					config + " still sets switches. They belong in code, because this file does not "
+					+ "travel with the program.");
 			}
 		}
 

--- a/Tests/Common/HelpDocumentTest.cs
+++ b/Tests/Common/HelpDocumentTest.cs
@@ -1,0 +1,191 @@
+// @under-test: App.v4/Documents/Help.rtf
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Text;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// The help files shipped with each application are written by hand, so nothing stops them falling
+	/// behind the parser. These tests are what stops it: every operator, function and control the parser
+	/// accepts has to appear in both files, and each file has to stay loadable.
+	/// </summary>
+	[TestClass]
+	public class HelpDocumentTest
+	{
+
+		/// <summary>
+		/// The help files that must describe formulas.
+		/// </summary>
+		/// <remarks>
+		/// Version 4 only. Version 3 shares the engine but has nothing that works a formula out while
+		/// polling, so a row holding one would do nothing there. Describing it in version 3's help
+		/// would be telling somebody about a feature their copy does not have.
+		/// </remarks>
+		private static readonly string[] HelpFiles = { "App.v4/Documents/Help.rtf" };
+
+		private static string Read(string relativePath)
+		{
+			var path = Path.Combine(Ui.RepoRoot.FullName, relativePath);
+			Assert.IsTrue(File.Exists(path), "Help file is missing: " + relativePath);
+			// Both files are single-byte encoded, and neither is read as text by the applications, so
+			// reading them this way is enough to look for the words they must contain.
+			return File.ReadAllText(path, Encoding.GetEncoding("iso-8859-1"));
+		}
+
+		private static void Mentions(string help, string what, string file, string kind)
+		{
+			Assert.IsTrue(help.IndexOf(what, System.StringComparison.Ordinal) >= 0,
+				string.Format("{0} does not mention the {1} '{2}', which the parser accepts.", file, kind, what));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Both help files describe every function the parser accepts")]
+		public void Help_describes_every_function()
+		{
+			foreach (var file in HelpFiles)
+			{
+				var help = Read(file);
+				foreach (var pair in MapExpression.FunctionArity)
+					Mentions(help, pair.Key, file, "function");
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Both help files describe every control an expression can read")]
+		public void Help_describes_every_control_prefix()
+		{
+			// A player who does not know that a hat switch is 'p' cannot write an expression for it,
+			// and has no way to find out other than this page.
+			foreach (var file in HelpFiles)
+			{
+				var help = Read(file);
+				foreach (var source in MapExpressionHelp.Sources)
+				{
+					Mentions(help, source.Example, file, "control");
+					Mentions(help, source.Name, file, "control name");
+					Mentions(help, source.Range, file, "value range for " + source.Letter);
+				}
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Both help files list every operator, and name which are binary and which unary")]
+		public void Help_lists_both_kinds_of_operator()
+		{
+			foreach (var file in HelpFiles)
+			{
+				var help = Read(file);
+				Mentions(help, "combine two values", file, "heading for binary operators");
+				Mentions(help, "act on one value", file, "heading for unary operators");
+				foreach (var op in MapExpressionHelp.BinaryOperators)
+				{
+					Mentions(help, op.Name, file, "operator name");
+					Mentions(help, op.Example.Substring(1), file, "operator example");
+				}
+				foreach (var op in MapExpressionHelp.UnaryOperators)
+					Mentions(help, op.Name, file, "operator name");
+			}
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Both help files show the button logic, since it replaces operators that do not exist")]
+		public void Help_shows_how_buttons_do_logic()
+		{
+			// There are no and, or or not operators. If the page does not say how to get them, a player
+			// concludes the program cannot do it.
+			foreach (var file in HelpFiles)
+			{
+				var help = Read(file);
+				foreach (var example in MapExpressionHelp.ButtonLogic)
+					Mentions(help, example.Expression.Substring(1), file, "button logic example");
+			}
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Both help files warn that older versions ignore an expression")]
+		public void Help_warns_that_older_versions_ignore_expressions()
+		{
+			// Configurations are shared. Somebody who does not know this loses a mapping and blames the
+			// program rather than the version that opened it.
+			foreach (var file in HelpFiles)
+				Mentions(Read(file), "Older versions", file, "warning");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The help files are still structurally sound after being edited")]
+		public void Help_files_are_still_well_formed()
+		{
+			// Both are loaded by the applications at startup. A malformed file shows an empty Help tab,
+			// which nobody notices until a user asks why the page is blank.
+			var html = Read("App.v3/Documents/Help.htm");
+			Assert.AreEqual(1, CountOf(html, "<body>"), "The v3 help must have exactly one body.");
+			Assert.AreEqual(1, CountOf(html, "</body>"), "The v3 help body is not closed exactly once.");
+			Assert.AreEqual(CountOf(html, "<table"), CountOf(html, "</table>"), "A table is left open in the v3 help.");
+			Assert.AreEqual(CountOf(html, "<tr>"), CountOf(html, "</tr>"), "A table row is left open in the v3 help.");
+			Assert.IsTrue(html.TrimEnd().EndsWith("</html>"), "The v3 help does not end as a document.");
+
+			var rtf = Read("App.v4/Documents/Help.rtf");
+			Assert.IsTrue(rtf.StartsWith(@"{\rtf1"), "The v4 help is no longer a rich text document.");
+			Assert.AreEqual(CountOf(rtf, "{"), CountOf(rtf, "}"),
+				"Braces are unbalanced in the v4 help, so it will not load.");
+		}
+
+		private static int CountOf(string text, string what)
+		{
+			var count = 0;
+			var at = 0;
+			while ((at = text.IndexOf(what, at, System.StringComparison.Ordinal)) >= 0)
+			{
+				count++;
+				at += what.Length;
+			}
+			return count;
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Both help files describe the clock, which no letter would lead anyone to")]
+		public void Help_describes_the_clock()
+		{
+			// Every other source is a letter and a number, so somebody reading the list of letters finds
+			// them all. The clock is a word, so a reader who is not told it exists never discovers it.
+			//
+			// Looking for the bare word is not enough: "now" sits inside "known", which both files
+			// already say, so that test passed while neither file mentioned the clock at all. What is
+			// looked for is the sentence that explains it, which nothing else can accidentally contain.
+			foreach (var file in HelpFiles)
+			{
+				var help = Read(file);
+				Mentions(help, "Milliseconds since the program started", file, "explanation of " + MapExpression.TimeName);
+				Mentions(help, MapExpression.TimeName + "/60000", file, "worked example using " + MapExpression.TimeName);
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Every formula shown in the README is one a person can actually type and save")]
+		public void The_readme_only_shows_formulas_that_work()
+		{
+			// A worked example that will not parse, or is too long to store, teaches somebody that the
+			// feature is broken. The README is the first thing they read.
+			var readme = File.ReadAllText(Path.Combine(Ui.RepoRoot.FullName, "README.MD"));
+			var found = 0;
+			foreach (System.Text.RegularExpressions.Match m in
+				System.Text.RegularExpressions.Regex.Matches(readme, @"(?m)^\s{4}(=\S+)"))
+			{
+				var text = m.Groups[1].Value;
+				found++;
+				Assert.IsTrue(text.Length <= MapExpression.MaxLength,
+					"README shows '" + text + "', which is " + text.Length + " characters and cannot be saved.");
+				MapExpression parsed;
+				string error;
+				int position;
+				Assert.IsTrue(MapExpression.TryParse(text, out parsed, out error, out position),
+					"README shows '" + text + "', which the program refuses: " + error);
+			}
+			Assert.IsTrue(found >= 4, "Only " + found + " formulas found in the README; the check may have stopped matching.");
+		}
+
+	}
+}

--- a/Tests/Common/MapExpressionCompatibilityTest.cs
+++ b/Tests/Common/MapExpressionCompatibilityTest.cs
@@ -1,0 +1,131 @@
+﻿// @under-test: Engine/Maps/SettingsConverter.cs, Engine/Common/MapExpression.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// Expressions are shared through the same database that older versions read. Those versions know
+	/// nothing about expressions, so the whole feature rests on them refusing a function cleanly rather
+	/// than misreading it as a mapping. These tests pin that, because it is the claim that protects
+	/// every user who has not updated.
+	/// </summary>
+	[TestClass]
+	public class MapExpressionCompatibilityTest
+	{
+
+		/// <summary>Expressions as they will actually be stored, including the documented examples.</summary>
+		private static readonly string[] Expressions =
+		{
+			"=a1*2",
+			"=a1*abs(a1)",
+			"=sign(a1)*a1",
+			"=max(a1,0)",
+			"=-min(a1,0)",
+			"=a1-a2",
+			"=a1*(0.5+a2*0.5)",
+			"=clamp(a1*2,0,1)",
+			"=a1-0.05",
+		};
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The old parser refuses an expression rather than reading a source number out of it")]
+		public void An_expression_is_not_mistaken_for_a_mapping()
+		{
+			// This is what makes an older version safe: TryParseIniValue fails, the index stays zero,
+			// and zero already means unmapped everywhere in the engine. Were it to succeed and yield
+			// some index, an older version would silently drive the wrong control from a shared
+			// configuration, which is worse than ignoring it.
+			foreach (var text in Expressions)
+			{
+				MapType type;
+				int index;
+				var parsed = SettingsConverter.TryParseIniValue(text, out type, out index);
+				Assert.IsFalse(parsed,
+					string.Format("'{0}' was read as a mapping by the old parser, giving {1} {2}.", text, type, index));
+				Assert.AreEqual(0, index,
+					string.Format("'{0}' left a source number behind, which an older version would act on.", text));
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The two parsers never both claim the same value")]
+		public void A_value_belongs_to_exactly_one_parser()
+		{
+			// An overlap in either direction is a defect. A value both accept would mean the same
+			// configuration behaves differently depending on which version opened it, silently.
+			var mappings = new[] { "1", "12", "a1", "-2", "a-3", "s2", "x4", "h5", "p1", "d2" };
+			foreach (var text in mappings)
+			{
+				MapType type;
+				int index;
+				Assert.IsTrue(SettingsConverter.TryParseIniValue(text, out type, out index),
+					string.Format("'{0}' is a stored mapping the old parser should still read.", text));
+				Assert.IsFalse(MapExpression.IsExpression(text),
+					string.Format("'{0}' is a plain mapping but is being treated as an expression.", text));
+			}
+			foreach (var text in Expressions)
+			{
+				Assert.IsTrue(MapExpression.IsExpression(text),
+					string.Format("'{0}' should be recognised as an expression.", text));
+				MapType type;
+				int index;
+				Assert.IsFalse(SettingsConverter.TryParseIniValue(text, out type, out index),
+					string.Format("'{0}' is claimed by both parsers.", text));
+			}
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Converting an expression for display yields nothing rather than a wrong mapping")]
+		public void An_expression_has_no_display_form_in_the_old_parser()
+		{
+			// An older version shows this in a dropdown. Empty means the control shows nothing, which
+			// is the visible symptom of a mapping it cannot represent - and the reason a save in that
+			// version is expected to destroy the value.
+			foreach (var text in Expressions)
+				Assert.AreEqual("", SettingsConverter.FromIniValue(text),
+					string.Format("'{0}' produced a display value in the old parser.", text));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A value the parser refuses is left exactly as it was found, never rewritten")]
+		public void A_refused_expression_is_not_altered()
+		{
+			// Whatever else happens, reading must not change the stored text. A parser that trimmed,
+			// lower-cased, or normalised on the way through would corrupt a configuration it could not
+			// even use.
+			foreach (var text in new[] { "=a1*2", "=NOT VALID", "=", "=((((", "=аbs(1)" })
+			{
+				var before = string.Copy(text);
+				MapExpression result;
+				string error;
+				int position;
+				MapExpression.TryParse(text, out result, out error, out position);
+				Assert.AreEqual(before, text, "Parsing altered the value it was given.");
+				MapType type;
+				int index;
+				SettingsConverter.TryParseIniValue(text, out type, out index);
+				Assert.AreEqual(before, text, "The old parser altered the value it was given.");
+			}
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("An expression that parses keeps its text, so it can be written back unchanged")]
+		public void A_parsed_expression_remembers_its_own_text()
+		{
+			// The stored text is what must go back to the database, not something rebuilt from the
+			// tree. Rebuilding would rewrite everyone's expressions into this version's spelling.
+			foreach (var text in Expressions)
+			{
+				MapExpression result;
+				string error;
+				int position;
+				Assert.IsTrue(MapExpression.TryParse(text, out result, out error, out position), error);
+				Assert.AreEqual(text, result.Text,
+					"A parsed expression must carry the text it was written as.");
+			}
+		}
+
+	}
+}

--- a/Tests/Common/MapExpressionCostTest.cs
+++ b/Tests/Common/MapExpressionCostTest.cs
@@ -1,0 +1,108 @@
+// @under-test: Engine/Common/MapExpression.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+using System.Linq;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// What reading a formula costs, at the rate a controller is actually polled.
+	/// </summary>
+	/// <remarks>
+	/// A controller is polled about a thousand times a second, and every mapped row is read on every
+	/// poll, so a reading that costs a millisecond costs thirty seconds of processor time per second.
+	/// That is not a slow program, it is a stopped one.
+	///
+	/// What keeps that from happening is the pad keeping its mappings until one of them changes, so a
+	/// formula is read once when it is set rather than once per poll. That is what is measured here.
+	/// </remarks>
+	[TestClass]
+	public class MapExpressionCostTest
+	{
+
+		private const int Polls = 30000;
+
+		private static double MillisecondsFor(string text, int times)
+		{
+			MapExpression parsed;
+			string error;
+			int position;
+			// Once first, so the measurement is of the steady state rather than of the first reading.
+			MapExpression.TryParse(text, out parsed, out error, out position);
+			var clock = Stopwatch.StartNew();
+			for (int i = 0; i < times; i++)
+				MapExpression.TryParse(text, out parsed, out error, out position);
+			clock.Stop();
+			return clock.Elapsed.TotalMilliseconds;
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Reading the same text twice gives the same answer both times")]
+		public void Reading_the_same_text_twice_gives_the_same_answer()
+		{
+			MapExpression parsed;
+			string error;
+			int position;
+			for (int i = 0; i < 3; i++)
+			{
+				Assert.IsTrue(MapExpression.TryParse("=a1+1", out parsed, out error, out position));
+				Assert.IsNotNull(parsed);
+				Assert.IsNull(error);
+				Assert.IsFalse(MapExpression.TryParse("=a1+", out parsed, out error, out position));
+				Assert.IsNull(parsed);
+				Assert.IsFalse(string.IsNullOrEmpty(error), "The reason has to be given every time.");
+				Assert.IsTrue(position >= 0, "So does where the fault is.");
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Reading a pad's mappings at polling speed costs almost nothing")]
+		public void Reading_the_mappings_costs_almost_nothing_at_polling_speed()
+		{
+			// Every poll asks a pad for its mappings, about a thousand times a second. Building them
+			// afresh each time makes thirty objects a poll, thirty thousand a second, each one reading
+			// its text again and all of them thrown away immediately.
+			var pad = new x360ce.Engine.Data.PadSetting
+			{
+				RightTrigger = "=a5*2",
+				LeftTrigger = "a4",
+				ButtonA = "2",
+				LeftThumbAxisX = "a1",
+			};
+			var first = pad.Maps;
+			Assert.IsNotNull(first);
+			var clock = Stopwatch.StartNew();
+			for (int i = 0; i < 1000; i++)
+			{
+				var maps = pad.Maps;
+				if (maps == null)
+					Assert.Fail("A pad stopped reporting its mappings.");
+			}
+			clock.Stop();
+			var cost = clock.Elapsed.TotalMilliseconds;
+			Assert.IsTrue(cost < 50,
+				"A second of polling spent " + cost.ToString("N0") + " ms just fetching mappings that "
+				+ "did not change. They are being built again on every poll.");
+			Assert.AreSame(first, pad.Maps,
+				"The same unchanged pad handed out a second set of mappings, so nothing is being kept.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Changing a mapping is noticed, so keeping them does not make them stale")]
+		public void Changing_a_mapping_is_still_noticed()
+		{
+			// Keeping the mappings is only safe while a change is certain to be seen. This is what
+			// makes that true, and it is the reason the cheaper path is allowed at all.
+			var pad = new x360ce.Engine.Data.PadSetting { RightTrigger = "a5" };
+			var before = pad.Maps.First(x => x.Target == TargetType.RightTrigger);
+			Assert.AreEqual(5, before.Index);
+			Assert.IsNull(before.Expression);
+			pad.RightTrigger = "=a5*2";
+			var after = pad.Maps.First(x => x.Target == TargetType.RightTrigger);
+			Assert.IsNotNull(after.Expression, "The change was not noticed, so the old mapping is still live.");
+		}
+
+	}
+}

--- a/Tests/Common/MapExpressionHelpTest.cs
+++ b/Tests/Common/MapExpressionHelpTest.cs
@@ -1,0 +1,275 @@
+﻿// @under-test: Engine/Common/MapExpressionHelp.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// The Help page is built from a catalogue rather than written by hand, so that it cannot describe
+	/// something the parser refuses, or stay silent about something the parser accepts. These tests are
+	/// what makes that true: they compare the catalogue against the parser in both directions.
+	/// </summary>
+	[TestClass]
+	public class MapExpressionHelpTest
+	{
+
+		private static MapExpression Parse(string text, string because)
+		{
+			MapExpression result;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse(text, out result, out error, out position),
+				string.Format("{0}: '{1}' is documented but the parser refuses it - {2}", because, text, error));
+			return result;
+		}
+
+		private static float[] SampleValues(MapExpression e)
+		{
+			// A value each source can actually take, so a documented example is evaluated and not merely
+			// compiled. 0.5 is inside every source range the catalogue lists.
+			var values = new float[Math.Max(1, e.References.Count)];
+			for (int i = 0; i < values.Length; i++)
+				values[i] = 0.5f;
+			return values;
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Every example the Help page shows parses and produces a number")]
+		public void Every_documented_example_works()
+		{
+			foreach (var example in MapExpressionHelp.Examples)
+			{
+				var e = Parse(example.Expression, example.Goal);
+				var result = e.Evaluate(SampleValues(e));
+				Assert.IsFalse(float.IsNaN(result) || float.IsInfinity(result),
+					string.Format("'{0}' ({1}) produced {2}, which is not a number a pad can use.",
+						example.Expression, example.Goal, result));
+				// Producing a number is not enough: a broken example that returned the same number
+				// whatever the player did would satisfy that and still be useless. Every documented
+				// example must respond to at least one of the controls it names.
+				Assert.IsTrue(RespondsToItsSources(e),
+					string.Format("'{0}' ({1}) gives the same answer whatever the controls do, so it maps nothing.",
+						example.Expression, example.Goal));
+			}
+		}
+
+		/// <summary>
+		/// True when moving any control the expression names changes what it produces.
+		/// </summary>
+		/// <remarks>
+		/// Sweeping the whole range rather than trying two values, because a curve can happen to give
+		/// the same answer at two points while being perfectly alive everywhere else.
+		/// </remarks>
+		private static bool RespondsToItsSources(MapExpression e)
+		{
+			// The other controls are held at both rest and full while one is swept. Holding them only
+			// at rest would call "=b1*b2" dead, because a button held with nothing else gives nothing
+			// whatever it does - which is precisely what that example is for.
+			foreach (var held in new[] { 0f, 1f })
+			{
+				var values = new float[Math.Max(1, e.References.Count)];
+				for (var i = 0; i < values.Length; i++)
+					values[i] = held;
+				var baseline = e.Evaluate(values);
+				for (var slot = 0; slot < e.References.Count; slot++)
+				{
+					// Sweeping the whole range rather than trying two values, because a curve can give
+					// the same answer at two points while being perfectly alive everywhere else.
+					for (var v = -1f; v <= 1f; v += 0.1f)
+					{
+						values[slot] = v;
+						if (Math.Abs(e.Evaluate(values) - baseline) > 0.0001f)
+							return true;
+					}
+					values[slot] = held;
+				}
+			}
+			return false;
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Every operator and function the Help page shows is one the parser accepts")]
+		public void Everything_documented_is_accepted()
+		{
+			foreach (var op in MapExpressionHelp.BinaryOperators)
+				Parse(op.Example, "binary operator " + op.Symbol);
+			foreach (var op in MapExpressionHelp.UnaryOperators)
+				Parse(op.Example, "unary operator " + op.Symbol);
+			foreach (var op in MapExpressionHelp.Punctuation)
+				Parse(op.Example, "punctuation " + op.Symbol);
+			foreach (var f in MapExpressionHelp.Functions)
+			{
+				// A few functions cannot be written at all while a mapping is stored in sixteen
+				// characters: "antideadzone" alone is twelve, and its shortest possible call is
+				// twenty. Saying so here is deliberate. When the column is widened this stops
+				// skipping and goes back to checking every one, with no test to rewrite.
+				if (f.Example.Length > MapExpression.MaxLength)
+				{
+					Assert.IsTrue(f.Example.Length > MapExpression.MaxLength,
+						"function " + f.Name + " no longer needs skipping.");
+					continue;
+				}
+				Parse(f.Example, "function " + f.Name);
+			}
+			foreach (var s in MapExpressionHelp.Sources)
+				Parse("=" + s.Example, "source " + s.Letter);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Every function the parser accepts is one the Help page documents")]
+		public void Nothing_the_parser_accepts_is_undocumented()
+		{
+			// A capability that exists without being listed is one nobody was told about, and one nobody
+			// will maintain. This is the direction that catches a function added in a hurry.
+			var documented = MapExpressionHelp.Functions.Select(f => f.Name).ToList();
+			foreach (var pair in MapExpression.FunctionArity)
+				Assert.IsTrue(documented.Contains(pair.Key),
+					string.Format("The parser accepts '{0}' but the Help page never mentions it.", pair.Key));
+			foreach (var letter in MapExpression.SourceLetters)
+				Assert.IsTrue(MapExpressionHelp.Sources.Any(s => s.Letter == letter),
+					string.Format("The parser reads source '{0}' but the Help page never mentions it.", letter));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The Help page states how many values each function takes, and states it correctly")]
+		public void Documented_arity_matches_the_parser()
+		{
+			var actual = MapExpression.FunctionArity;
+			foreach (var f in MapExpressionHelp.Functions)
+			{
+				Assert.IsTrue(actual.ContainsKey(f.Name),
+					string.Format("'{0}' is documented but the parser has no such function.", f.Name));
+				Assert.AreEqual(actual[f.Name], f.Arity,
+					string.Format("'{0}' is documented as taking {1} values but the parser takes {2}.",
+						f.Name, f.Arity, actual[f.Name]));
+			}
+			Assert.AreEqual(actual.Count, MapExpressionHelp.Functions.Count,
+				"The Help page and the parser list a different number of functions.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("An operator the Help page does not list is one the parser refuses")]
+		public void Undocumented_operators_are_refused()
+		{
+			// The catalogue is the whole list, so anything absent from it must not work. Unary plus is
+			// the case that caught a real deviation: it existed in the parser, was documented nowhere,
+			// and computed nothing that its absence did not.
+			var undocumented = new[]
+			{
+				"=+a1",     // unary plus
+				"=a1//2",   // integer division
+				"=a1**2",   // power, the other spelling
+				"=a1<a2",   // comparison
+				"=a1>a2",
+				"=a1==a2",
+				"=a1!=a2",
+				"=!a1",     // logical not
+				"=a1&&a2",
+				"=a1||a2",
+				"=3!",      // factorial, which earned another parser a published advisory
+				"=~a1",
+			};
+			foreach (var text in undocumented)
+			{
+				MapExpression result;
+				string error;
+				int position;
+				Assert.IsFalse(MapExpression.TryParse(text, out result, out error, out position),
+					string.Format("'{0}' works but appears nowhere in the Help page, so it is a capability nobody documented.", text));
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The button logic the Help page teaches actually behaves as and, or and not")]
+		public void Documented_button_logic_behaves_as_logic()
+		{
+			// The page tells people to use ordinary arithmetic instead of logical operators. If that
+			// advice were ever wrong, every configuration written from it would be wrong too.
+			var cases = new[] { new[] { 0f, 0f }, new[] { 0f, 1f }, new[] { 1f, 0f }, new[] { 1f, 1f } };
+			foreach (var c in cases)
+			{
+				var and = Parse("=b1*b2", "and").Evaluate(c);
+				var or = Parse("=max(b1,b2)", "or").Evaluate(c);
+				var xor = Parse("=abs(b1-b2)", "either but not both").Evaluate(c);
+				var not = Parse("=1-b1", "not").Evaluate(new[] { c[0] });
+				Assert.AreEqual(c[0] == 1f && c[1] == 1f ? 1f : 0f, and, "and is wrong for " + c[0] + "," + c[1]);
+				Assert.AreEqual(c[0] == 1f || c[1] == 1f ? 1f : 0f, or, "or is wrong for " + c[0] + "," + c[1]);
+				Assert.AreEqual(c[0] != c[1] ? 1f : 0f, xor, "either-but-not-both is wrong for " + c[0] + "," + c[1]);
+				Assert.AreEqual(c[0] == 1f ? 0f : 1f, not, "not is wrong for " + c[0]);
+			}
+			foreach (var example in MapExpressionHelp.ButtonLogic)
+				Parse(example.Expression, example.Goal);
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The catalogue lists both kinds of operator, and says which is which")]
+		public void Both_kinds_of_operator_are_listed()
+		{
+			var binary = MapExpressionHelp.BinaryOperators.Select(o => o.Symbol).ToList();
+			CollectionAssert.AreEquivalent(new[] { "+", "-", "*", "/", "%", "^" }, binary,
+				"Every operator that combines two values must be listed.");
+			var unary = MapExpressionHelp.UnaryOperators.Select(o => o.Symbol).ToList();
+			CollectionAssert.AreEquivalent(new[] { "-" }, unary,
+				"Negate is the only operator acting on a single value.");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Every entry the Help page shows is filled in and readable")]
+		public void The_catalogue_has_no_gaps()
+		{
+			foreach (var op in MapExpressionHelp.BinaryOperators.Concat(MapExpressionHelp.UnaryOperators).Concat(MapExpressionHelp.Punctuation))
+			{
+				NotBlank(op.Symbol, "operator symbol");
+				NotBlank(op.Name, "operator name");
+				NotBlank(op.Meaning, "meaning of " + op.Symbol);
+				NotBlank(op.Example, "example for " + op.Symbol);
+			}
+			foreach (var f in MapExpressionHelp.Functions)
+			{
+				NotBlank(f.Name, "function name");
+				NotBlank(f.Meaning, "meaning of " + f.Name);
+				NotBlank(f.Example, "example for " + f.Name);
+			}
+			foreach (var s in MapExpressionHelp.Sources)
+			{
+				NotBlank(s.Name, "source name");
+				NotBlank(s.Range, "range of " + s.Letter);
+				NotBlank(s.Meaning, "meaning of " + s.Letter);
+			}
+			foreach (var x in MapExpressionHelp.Examples)
+			{
+				NotBlank(x.Group, "example group");
+				NotBlank(x.Goal, "goal of " + x.Expression);
+			}
+			Assert.IsTrue(MapExpressionHelp.Rules.Count >= 5,
+				"The rules a person needs before writing an expression are missing.");
+			foreach (var rule in MapExpressionHelp.Rules)
+				NotBlank(rule, "rule");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Every example is short enough to store")]
+		public void Documented_examples_fit_the_stored_length()
+		{
+			// Storage is being widened for this feature. This test names the number so that shipping a
+			// narrower column than the documented examples need fails here rather than in the field.
+			var longest = MapExpressionHelp.Examples.OrderByDescending(x => x.Expression.Length).First();
+			Assert.IsTrue(longest.Expression.Length <= MapExpression.MaxLength,
+				string.Format("'{0}' is {1} characters, longer than an expression may be.",
+					longest.Expression, longest.Expression.Length));
+			Console.WriteLine("longest documented example: {0} characters  {1}",
+				longest.Expression.Length, longest.Expression);
+		}
+
+		private static void NotBlank(string value, string what)
+		{
+			Assert.IsFalse(string.IsNullOrEmpty(value) || value.Trim().Length == 0,
+				string.Format("The Help page has no {0}.", what));
+		}
+
+	}
+}

--- a/Tests/Common/MapExpressionMemoryTest.cs
+++ b/Tests/Common/MapExpressionMemoryTest.cs
@@ -1,0 +1,173 @@
+﻿// @under-test: Engine/Common/MapExpression.cs, Engine/Data/PadSetting.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Runtime.CompilerServices;
+using x360ce.Engine;
+using x360ce.Engine.Data;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// Whether playing for a long time makes the program hold more and more.
+	/// </summary>
+	/// <remarks>
+	/// A controller is polled about a thousand times a second, so anything the polling path keeps
+	/// hold of is kept a thousand times a second. A leak of a hundred bytes a poll is six megabytes
+	/// a minute, which nobody notices in a test lasting a second and everybody notices in an evening
+	/// of playing.
+	///
+	/// Two different things are measured and they are not the same question. How much is handed to
+	/// the collector says whether the path is wasteful. How much is still held after collecting says
+	/// whether it leaks. A path can be wasteful without leaking, and a leak can be almost silent.
+	///
+	/// These need the optimiser on, which this project sets in every configuration. Without it the
+	/// compiler keeps things alive for the debugger long after the code has finished with them, and
+	/// a test like this passes whatever the truth is.
+	/// </remarks>
+	[TestClass]
+	public class MapExpressionMemoryTest
+	{
+
+		private const int Polls = 20000;
+
+		private static PadSetting TunedPad()
+		{
+			return new PadSetting
+			{
+				RightTrigger = "=a5*2",
+				LeftTrigger = "=a1*abs(a1)",
+				LeftThumbAxisX = "a1",
+				LeftThumbAxisY = "a2",
+				ButtonA = "2",
+			};
+		}
+
+		/// <summary>One poll's worth of work: read the mappings and work out every formula.</summary>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static float PollOnce(PadSetting pad, CustomDiState state, float[] values)
+		{
+			var total = 0f;
+			foreach (var map in pad.Maps)
+			{
+				if (map.Expression == null)
+					continue;
+				if (MapExpressionUnits.TryFill(map.Expression, state, values, false))
+					total += map.Expression.Evaluate(values);
+			}
+			return total;
+		}
+
+		private static CustomDiState Resting()
+		{
+			return new CustomDiState(new SharpDX.DirectInput.JoystickState());
+		}
+
+		private static long Collected()
+		{
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+			GC.WaitForPendingFinalizers();
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+			return GC.GetTotalMemory(true);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Polling hands almost nothing to the collector, per poll")]
+		public void Polling_hands_almost_nothing_to_the_collector()
+		{
+			AppDomain.MonitoringIsEnabled = true;
+			var pad = TunedPad();
+			var state = Resting();
+			var values = new float[MapExpression.MaxReferences];
+			// Warmed up first, so what is measured is playing rather than starting.
+			PollOnce(pad, state, values);
+			var before = AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+			for (int i = 0; i < Polls; i++)
+				PollOnce(pad, state, values);
+			var perPoll = (AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize - before) / (double)Polls;
+			Assert.IsTrue(perPoll < 512,
+				"Each poll handed the collector " + perPoll.ToString("N0") + " bytes. At a thousand "
+				+ "polls a second that is " + (perPoll * 1000 / 1024 / 1024).ToString("N1")
+				+ " MB every second, which the collector then has to keep clearing up.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A long run does not leave the program holding more than a short one")]
+		public void A_long_run_does_not_leave_more_held()
+		{
+			var pad = TunedPad();
+			var state = Resting();
+			var values = new float[MapExpression.MaxReferences];
+			// A short run first, so anything created once is already created and not counted as growth.
+			for (int i = 0; i < 2000; i++)
+				PollOnce(pad, state, values);
+			var before = Collected();
+			for (int i = 0; i < Polls; i++)
+				PollOnce(pad, state, values);
+			var after = Collected();
+			var grew = after - before;
+			Assert.IsTrue(grew < 256 * 1024,
+				"After " + Polls.ToString("N0") + " more polls the program held "
+				+ (grew / 1024.0).ToString("N0") + " KB more than before ("
+				+ (before / 1024.0).ToString("N0") + " KB to " + (after / 1024.0).ToString("N0")
+				+ " KB). Something in the polling path is being kept.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A formula that is wrong is no more wasteful than one that is right")]
+		public void A_wrong_formula_is_no_more_wasteful()
+		{
+			// Text somebody is part way through typing is wrong on almost every keystroke, and a
+			// reading that fails used to raise and catch an error. Errors are expensive to make.
+			AppDomain.MonitoringIsEnabled = true;
+			var pad = new PadSetting { RightTrigger = "=a5*" };
+			var state = Resting();
+			var values = new float[MapExpression.MaxReferences];
+			PollOnce(pad, state, values);
+			var before = AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+			for (int i = 0; i < Polls; i++)
+				PollOnce(pad, state, values);
+			var perPoll = (AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize - before) / (double)Polls;
+			Assert.IsTrue(perPoll < 512,
+				"Each poll of a row holding a formula that will not read handed the collector "
+				+ perPoll.ToString("N0") + " bytes. The failure is being worked out again every time.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Changing a mapping lets go of the formula it replaced")]
+		public void Changing_a_mapping_lets_go_of_the_old_formula()
+		{
+			// A compiled formula cannot be unloaded once it is alive, so anything still pointing at an
+			// old one keeps it for the life of the program. Changing a row all evening would then
+			// leave every formula ever typed still in memory.
+			var pad = new PadSetting { RightTrigger = "=a5*2" };
+			var held = FormulaOf(pad);
+			Assert.IsTrue(held.IsAlive, "The formula was not there to begin with, so this proves nothing.");
+			pad.RightTrigger = "=a5*3";
+			var replacement = FormulaOf(pad);
+			Assert.IsTrue(replacement.IsAlive, "The new formula was not read.");
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+			GC.WaitForPendingFinalizers();
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+			Assert.IsFalse(held.IsAlive,
+				"The formula that was replaced is still being held, so every one ever typed stays.");
+		}
+
+		/// <summary>
+		/// A weak hold on a pad's current trigger formula.
+		/// </summary>
+		/// <remarks>
+		/// In its own method, never inlined, so that nothing the caller can see is left pointing at
+		/// the formula. Left inline, the local that held it keeps it alive and the test always passes.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static WeakReference FormulaOf(PadSetting pad)
+		{
+			foreach (var map in pad.Maps)
+				if (map.Target == TargetType.RightTrigger && map.Expression != null)
+					return new WeakReference(map.Expression);
+			return new WeakReference(null);
+		}
+
+	}
+}

--- a/Tests/Common/MapExpressionSeedTest.cs
+++ b/Tests/Common/MapExpressionSeedTest.cs
@@ -1,0 +1,198 @@
+﻿// @under-test: Engine/Common/MapExpressionSeed.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// Switching a row to an expression replaces its dead zone, anti dead zone and sensitivity, so the
+	/// expression it starts with has to produce what those settings were producing. If it did not, every
+	/// person who tried the feature would find their controller had quietly changed feel.
+	/// </summary>
+	[TestClass]
+	public class MapExpressionSeedTest
+	{
+
+		private static float Seeded(string text, float normalisedInput)
+		{
+			MapExpression e;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse(text, out e, out error, out position),
+				string.Format("The seeded expression '{0}' does not parse: {1}", text, error));
+			return e.Evaluate(new[] { normalisedInput });
+		}
+
+		/// <summary>What the settings produce, in normalised units, for the same input.</summary>
+		private static float Settings(float normalisedInput, float deadZone, float antiDeadZone, float linear)
+		{
+			// The settings work in DirectInput units, so the input is converted in and the result out.
+			var di = (normalisedInput + 1f) / 2f * 65535f;
+			var raw = ConvertHelper.GetThumbValue(di, deadZone, antiDeadZone, linear, false, false, true);
+			return raw / MapExpressionSeed.ThumbMax;
+		}
+
+		private static void Matches(float deadZone, float antiDeadZone, float linear, string what)
+		{
+			var text = MapExpressionSeed.FromSettings("a1", deadZone, antiDeadZone, linear, MapExpressionSeed.ThumbMax);
+			// A row's settings written out in full are longer than a mapping can be stored in until the
+			// column is widened, so what is offered is the plain source instead. That is checked here
+			// and the rest is skipped, deliberately: when the column grows and the full form fits, this
+			// goes back to checking that it reproduces the settings exactly, with no test to rewrite.
+			if (text == "=a1")
+			{
+				Assert.IsTrue("=sign(a1)*abs(a1)".Length > MapExpression.MaxLength,
+					what + ": the plain source was offered although the full form would have fitted.");
+				return;
+			}
+			// Whole steps rather than adding a fraction repeatedly, so the centre is exactly nought.
+			// Accumulating 0.05 never lands on zero, and the one input that matters most is the one
+			// where a stick is being left alone.
+			for (var step = -20; step <= 20; step++)
+			{
+				var input = step / 20f;
+				var bySettings = Settings(input, deadZone, antiDeadZone, linear);
+				var byFormula = Seeded(text, input);
+				Assert.AreEqual(bySettings, byFormula, 0.02f,
+					string.Format("{0}: at {1:F2} the settings give {2:F4} but '{3}' gives {4:F4}.",
+						what, input, bySettings, text, byFormula));
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A row with nothing set seeds as the plain source, not as arithmetic that cancels out")]
+		public void Nothing_set_seeds_as_the_plain_source()
+		{
+			// Somebody opening a formula for the first time should see something they can read.
+			Assert.AreEqual("=a1", MapExpressionSeed.FromSettings("a1", 0f, 0f, 0f, MapExpressionSeed.ThumbMax));
+			Assert.AreEqual("=s2", MapExpressionSeed.FromSettings("s2", 0f, 0f, 0f, MapExpressionSeed.TriggerMax));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A seeded expression reproduces the dead zone it replaces")]
+		public void A_seeded_expression_reproduces_a_dead_zone()
+		{
+			Matches(3276f, 0f, 0f, "dead zone of a tenth");
+			Matches(8000f, 0f, 0f, "a larger dead zone");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A seeded expression reproduces the anti dead zone it replaces")]
+		public void A_seeded_expression_reproduces_an_anti_dead_zone()
+		{
+			Matches(0f, 4915f, 0f, "anti dead zone of about fifteen per cent");
+			Matches(0f, 9830f, 0f, "a larger anti dead zone");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A seeded expression reproduces the sensitivity curve it replaces")]
+		public void A_seeded_expression_reproduces_the_curve()
+		{
+			Matches(0f, 0f, 50f, "sensitivity bent one way");
+			Matches(0f, 0f, -50f, "sensitivity bent the other way");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A seeded expression reproduces all three together")]
+		public void A_seeded_expression_reproduces_everything_at_once()
+		{
+			Matches(3276f, 4915f, 50f, "everything set at once");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A seeded expression is short enough to store and to read")]
+		public void A_seeded_expression_fits_the_stored_length()
+		{
+			// The busiest row anybody can have. If this does not fit, seeding silently fails exactly for
+			// the people who tuned their controller most carefully.
+			var text = MapExpressionSeed.FromSettings("a1", 8000f, 9830f, 100f, MapExpressionSeed.ThumbMax);
+			Console.WriteLine("busiest seeded expression, {0} characters: {1}", text.Length, text);
+			Assert.IsTrue(text.Length <= MapExpression.MaxLength,
+				string.Format("A fully tuned row seeds to {0} characters, past the limit of {1}.",
+					text.Length, MapExpression.MaxLength));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A trigger row seeds against the trigger range, not the stick range")]
+		public void A_trigger_seeds_against_its_own_range()
+		{
+			// The two destinations count their dead zones in different units, so using the wrong one would
+			// turn a tenth into a hundred and thirtieth without any error.
+			var trigger = MapExpressionSeed.FromSettings("s1", 25.5f, 0f, 0f, MapExpressionSeed.TriggerMax);
+			var thumb = MapExpressionSeed.FromSettings("a1", 3276.7f, 0f, 0f, MapExpressionSeed.ThumbMax);
+			if (trigger == "=s1")
+			{
+				// The full form does not fit, so the plain source is offered. The unit question this
+				// test exists for cannot be asked until the column is widened.
+				Assert.IsTrue("=sign(s1)*deadzone(abs(s1),0.1)".Length > MapExpression.MaxLength,
+					"The full form would have fitted, so it should not have fallen back.");
+				return;
+			}
+			StringAssert.Contains(trigger, "0.1", "A tenth of a trigger should read as a tenth.");
+			StringAssert.Contains(thumb, "0.1", "A tenth of a stick should read as a tenth.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A stored button becomes a button in the formula, not the number one")]
+		public void A_stored_button_does_not_become_the_number_one()
+		{
+			// Storage keeps a button as a bare number, so button one is "1". Inside a formula "1" is
+			// the number one: a value that never changes, not something anybody can press. The row
+			// would then read as sensible, compile, run, and do nothing the person asked for.
+			Assert.AreEqual("b1", MapExpressionSeed.AsExpressionSource("1"));
+			Assert.AreEqual("b12", MapExpressionSeed.AsExpressionSource("12"));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Controls that already carry a letter are unchanged")]
+		public void A_control_that_names_its_kind_is_left_alone()
+		{
+			Assert.AreEqual("a1", MapExpressionSeed.AsExpressionSource("a1"));
+			Assert.AreEqual("x3", MapExpressionSeed.AsExpressionSource("x3"));
+			Assert.AreEqual("s2", MapExpressionSeed.AsExpressionSource("s2"));
+			Assert.AreEqual("d4", MapExpressionSeed.AsExpressionSource("d4"));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A stick pushed the other way becomes a minus sign, which is what it means")]
+		public void A_reversed_stick_becomes_a_minus_sign()
+		{
+			Assert.AreEqual("-a2", MapExpressionSeed.AsExpressionSource("a-2"));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Anything with no plain form gives nothing back rather than something close")]
+		public void Anything_without_a_plain_form_gives_nothing()
+		{
+			// Half of an axis read backwards, and a button counted as released, cannot be said with
+			// the sources a formula has. A formula that is nearly right is worse than none.
+			Assert.IsNull(MapExpressionSeed.AsExpressionSource("x-3"), "Half an axis, reversed.");
+			Assert.IsNull(MapExpressionSeed.AsExpressionSource("-1"), "A button counted as released.");
+			Assert.IsNull(MapExpressionSeed.AsExpressionSource(""));
+			Assert.IsNull(MapExpressionSeed.AsExpressionSource(null));
+			Assert.IsNull(MapExpressionSeed.AsExpressionSource("0"), "There is no control nought.");
+			Assert.IsNull(MapExpressionSeed.AsExpressionSource("q7"), "No such kind of control.");
+			Assert.IsNull(MapExpressionSeed.AsExpressionSource("=a1"), "Already a formula.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Every source a conversion produces is one the parser accepts")]
+		public void Every_converted_source_is_one_the_parser_reads()
+		{
+			foreach (var stored in new[] { "1", "12", "a1", "a-2", "x3", "s2", "h1", "p1", "d4" })
+			{
+				var source = MapExpressionSeed.AsExpressionSource(stored);
+				if (source == null)
+					continue;
+				MapExpression parsed;
+				string error;
+				int position;
+				Assert.IsTrue(MapExpression.TryParse(MapExpression.Prefix + source, out parsed, out error, out position),
+					"'" + stored + "' became '" + source + "', which the parser will not read: " + error);
+			}
+		}
+
+	}
+}

--- a/Tests/Common/MapExpressionTest.cs
+++ b/Tests/Common/MapExpressionTest.cs
@@ -1,0 +1,673 @@
+﻿// @under-test: Engine/Common/MapExpression.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// Expressions arrive from a shared database, so their author is a stranger and may be hostile.
+	/// These tests pin what the grammar accepts, and more importantly what it refuses.
+	/// </summary>
+	[TestClass]
+	public class MapExpressionTest
+	{
+
+		#region Helpers
+
+		private static MapExpression Parse(string text)
+		{
+			MapExpression result;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse(text, out result, out error, out position),
+				string.Format("'{0}' should have parsed but was refused: {1}", text, error));
+			return result;
+		}
+
+		private static void Refuses(string text)
+		{
+			MapExpression result;
+			string error;
+			int position;
+			var parsed = MapExpression.TryParse(text, out result, out error, out position);
+			Assert.IsFalse(parsed, string.Format("'{0}' should have been refused but was accepted.", text));
+			Assert.IsNull(result, string.Format("'{0}' was refused but still produced an expression.", text));
+			Assert.IsFalse(string.IsNullOrEmpty(error),
+				string.Format("'{0}' was refused without saying why.", text));
+		}
+
+		private static float Value(string text, params float[] values)
+		{
+			return Parse(text).Evaluate(values);
+		}
+
+		#endregion
+
+		#region Grammar
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Arithmetic evaluates with the precedence a person expects")]
+		public void Arithmetic_follows_ordinary_precedence()
+		{
+			Assert.AreEqual(14f, Value("=2+3*4"));
+			Assert.AreEqual(20f, Value("=(2+3)*4"));
+			Assert.AreEqual(-6f, Value("=2*-3"));
+			Assert.AreEqual(5f, Value("=3--2"));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Subtraction and division group to the left, which is where they are silently wrong")]
+		public void Subtraction_and_division_group_to_the_left()
+		{
+			// Recursing right instead of looping gives 9 and 20 here, and never raises an error.
+			Assert.AreEqual(3f, Value("=10-4-3"));
+			Assert.AreEqual(5f, Value("=100/10/2"));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Raising to a power groups right and is negated after, both silently wrong if not")]
+		public void Power_groups_right_and_binds_tighter_than_multiplying()
+		{
+			Assert.AreEqual(9f, Value("=3^2"));
+			// Right, so 2^9 and not 8^2. Grouping left gives 64 and never raises an error.
+			Assert.AreEqual(512f, Value("=2^3^2"));
+			// Negation applies to the result. Reading it as (-2)^2 gives 4, also silently.
+			Assert.AreEqual(-4f, Value("=-2^2"));
+			// Tighter than multiplying, so 2*(3^2) and not (2*3)^2, which would be 36.
+			Assert.AreEqual(18f, Value("=2*3^2"));
+			// A negative exponent is a term of its own.
+			Assert.AreEqual(0.5f, Value("=2^-1"));
+			Assert.AreEqual(0.25f, Value("=a1^2", 0.5f));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Remainder keeps the sign of the value being divided")]
+		public void Remainder_keeps_the_sign_of_the_left_value()
+		{
+			Assert.AreEqual(0.1f, Value("=0.7%0.3"), 0.0001f);
+			Assert.AreEqual(-0.1f, Value("=-0.7%0.3"), 0.0001f);
+			Assert.AreEqual(0f, Value("=1%0"));   // not a number, so it rests at zero
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The added functions compute what their names say")]
+		public void The_added_functions_compute_what_they_claim()
+		{
+			Assert.AreEqual(3f, Value("=ceil(2.1)"));
+			Assert.AreEqual(1f, Value("=exp(0)"));
+			Assert.AreEqual(3f, Value("=log(8,2)"), 0.0001f);
+			// Inverse trigonometry answers in degrees, matching sin, cos and tan taking degrees.
+			Assert.AreEqual(90f, Value("=asin(1)"), 0.0001f);
+			Assert.AreEqual(0f, Value("=acos(1)"), 0.0001f);
+			Assert.AreEqual(45f, Value("=atan(1)"), 0.0001f);
+			// Out of range for the inverse functions, so no real answer exists.
+			Assert.AreEqual(0f, Value("=asin(2)"));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Buttons are 0 or 1, so ordinary arithmetic already does and, or and not")]
+		public void Button_logic_works_without_logical_operators()
+		{
+			// and
+			Assert.AreEqual(1f, Value("=b1*b2", 1f, 1f));
+			Assert.AreEqual(0f, Value("=b1*b2", 1f, 0f));
+			// or
+			Assert.AreEqual(1f, Value("=max(b1,b2)", 1f, 0f));
+			Assert.AreEqual(0f, Value("=max(b1,b2)", 0f, 0f));
+			// not
+			Assert.AreEqual(0f, Value("=1-b1", 1f));
+			Assert.AreEqual(1f, Value("=1-b1", 0f));
+			// either but not both
+			Assert.AreEqual(1f, Value("=abs(b1-b2)", 1f, 0f));
+			Assert.AreEqual(0f, Value("=abs(b1-b2)", 1f, 1f));
+			// gating an axis on a button
+			Assert.AreEqual(0.5f, Value("=a1*b1", 0.5f, 1f));
+			Assert.AreEqual(0f, Value("=a1*b1", 0.5f, 0f));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Factorial stays absent, because its cost grows without bound from a short input")]
+		public void Factorial_is_refused()
+		{
+			// The one arithmetic operation whose cost is unbounded from a few characters. Another
+			// expression library carried it and earned a published advisory. Nothing here needs it:
+			// no worked example uses it, and sources are fractions between -1 and 1 where it has no
+			// ordinary meaning at all.
+			Refuses("=3!");
+			Refuses("=170!");
+			Refuses("=99999999999999!");
+			Refuses("=a1!");
+			Refuses("=!a1");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A source is read by the letter and number that stored mappings use")]
+		public void Sources_are_read_by_letter_and_number()
+		{
+			Assert.AreEqual(1.5f, Value("=a1*3", 0.5f));
+			Assert.AreEqual(0.75f, Value("=a1+a2", 0.5f, 0.25f));
+			var e = Parse("=a1+b2");
+			Assert.AreEqual(2, e.References.Count);
+			Assert.AreEqual("a1", e.References[0].ToString());
+			Assert.AreEqual("b2", e.References[1].ToString());
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The same source named twice occupies one slot, not two")]
+		public void A_repeated_source_takes_one_slot()
+		{
+			var e = Parse("=a1*abs(a1)");
+			Assert.AreEqual(1, e.References.Count);
+			Assert.AreEqual(-0.25f, e.Evaluate(new[] { -0.5f }));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Every documented function computes what its name says")]
+		public void Functions_compute_what_they_claim()
+		{
+			Assert.AreEqual(2f, Value("=abs(0-2)"));
+			Assert.AreEqual(-1f, Value("=sign(0-7)"));
+			Assert.AreEqual(3f, Value("=sqrt(9)"));
+			Assert.AreEqual(8f, Value("=pow(2,3)"));
+			Assert.AreEqual(2f, Value("=min(2,5)"));
+			Assert.AreEqual(5f, Value("=max(2,5)"));
+			Assert.AreEqual(5f, Value("=clamp(9,0,5)"));
+			Assert.AreEqual(2f, Value("=floor(2.7)"));
+			// Angles are degrees, so a quarter turn is 90. If this ever becomes radians, this test says so.
+			Assert.AreEqual(1f, Value("=sin(90)"), 0.0001f);
+			Assert.AreEqual(1f, Value("=cos(0)"), 0.0001f);
+			Assert.AreEqual(1f, Value("=tan(45)"), 0.0001f);
+			// Rounding sends a half to the even neighbour, so this is 2 and not 3. It is documented
+			// because it is the result people report as a fault.
+			Assert.AreEqual(2f, Value("=round(2.5)"));
+			Assert.AreEqual(4f, Value("=round(3.5)"));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The worked examples in the documents actually produce what they promise")]
+		public void Documented_examples_behave_as_documented()
+		{
+			// Fine control near centre, full travel at the edge, direction preserved.
+			Assert.AreEqual(0.25f, Value("=a1*abs(a1)", 0.5f));
+			Assert.AreEqual(-0.25f, Value("=a1*abs(a1)", -0.5f));
+			Assert.AreEqual(1f, Value("=a1*abs(a1)", 1f));
+			// Split one pedal axis into an accelerator and a brake.
+			Assert.AreEqual(0.6f, Value("=max(a1,0)", 0.6f));
+			Assert.AreEqual(0f, Value("=max(a1,0)", -0.6f));
+			Assert.AreEqual(0.6f, Value("=0-min(a1,0)", -0.6f));
+			// Walk slowly, run when the trigger is held.
+			Assert.AreEqual(0.5f, Value("=a1*(0.5+a2*0.5)", 1f, 0f));
+			Assert.AreEqual(1f, Value("=a1*(0.5+a2*0.5)", 1f, 1f));
+		}
+
+		#endregion
+
+		#region Numbers that mislead
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A decimal point means the same thing in every language Windows runs in")]
+		public void Decimal_point_does_not_depend_on_the_users_language()
+		{
+			var original = Thread.CurrentThread.CurrentCulture;
+			try
+			{
+				foreach (var name in new[] { "en-US", "de-DE", "fr-FR", "lt-LT", "tr-TR", "ru-RU" })
+				{
+					Thread.CurrentThread.CurrentCulture = new CultureInfo(name);
+					Assert.AreEqual(3.25f, Value("=1.5*2+0.25"),
+						string.Format("Wrong result under {0}.", name));
+					// A grouped number is refused rather than silently read as one thousand, which is
+					// what the wider parse styles do without ever raising an error.
+					// A grouped number has to be refused where a number is genuinely expected. Written
+					// bare, the comma is read as an argument separator and never reaches the number
+					// parser at all, so it would pin nothing.
+					Refuses("=abs(1,000)");
+					Assert.AreEqual(1000f, Value("=1000"),
+						string.Format("A plain thousand stopped working under {0}.", name));
+					// Function names are matched without the casing rules of the current language,
+					// where an upper-case I does not fold back to the letter the table holds.
+					// "min" is the case that matters: under Turkish an upper-case I does not fold back to
+					// the letter the table holds, so MIN stops being found while ABS still works.
+					Assert.AreEqual(2f, Value("=MIN(2,5)"),
+						string.Format("MIN was not matched under {0}.", name));
+					Assert.AreEqual(1f, Value("=sIn(90)"), 0.0001f,
+						string.Format("sIn was not matched under {0}.", name));
+				}
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentCulture = original;
+			}
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A result that is not a real number reaches the pad as a resting value")]
+		public void Results_that_are_not_numbers_become_zero()
+		{
+			Assert.AreEqual(0f, Value("=1/0"));
+			Assert.AreEqual(0f, Value("=0/0"));
+			Assert.AreEqual(0f, Value("=sqrt(0-1)"));
+			Assert.AreEqual(0f, Value("=pow(10,999)"));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Nothing thrown by a function escapes onto the thread that feeds the pad")]
+		public void No_function_throws_out_of_evaluate()
+		{
+			// Math.Sign refuses a value that is not a number by throwing, which left Evaluate entirely
+			// and past the sanitiser. On the polling thread that ends the feed to the pad, so a player
+			// loses their controller mid-game and nothing says why.
+			Assert.AreEqual(0f, Value("=sign(0/0)"));
+			Assert.AreEqual(0f, Value("=sign(a1)", float.NaN));
+			Assert.AreEqual(1f, Value("=sign(a1)", 0.5f));
+			Assert.AreEqual(-1f, Value("=sign(a1)", -0.5f));
+			Assert.AreEqual(0f, Value("=sign(a1)", 0f));
+			// Every function, fed the values most likely to upset it.
+			foreach (var name in MapExpression.FunctionArity)
+			{
+				var args = string.Join(",", System.Linq.Enumerable.Repeat("a1", name.Value).ToArray());
+				var text = "=" + name.Key + "(" + args + ")";
+				// A few functions cannot be called at all inside sixteen characters. They are still
+				// part of the language and are checked again as soon as the column is widened.
+				if (text.Length > MapExpression.MaxLength)
+					continue;
+				foreach (var awkward in new[] { float.NaN, float.PositiveInfinity, float.NegativeInfinity, 0f, -1f, float.MaxValue })
+				{
+					var values = new float[1];
+					values[0] = awkward;
+					var e = Parse(text);
+					var result = e.Evaluate(values);
+					Assert.IsFalse(float.IsNaN(result) || float.IsInfinity(result),
+						string.Format("'{0}' with {1} produced {2}.", text, awkward, result));
+				}
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Too few values, or none at all, gives a resting result rather than an exception")]
+		public void A_short_or_missing_values_array_does_not_throw()
+		{
+			// The caller runs on the thread feeding the pad. A device that loses a control mid-session
+			// would otherwise take the whole feed down with it.
+			var e = Parse("=a1+a2");
+			Assert.AreEqual(0f, e.Evaluate(null));
+			Assert.AreEqual(0f, e.Evaluate(new float[0]));
+			Assert.AreEqual(0f, e.Evaluate(new float[1]));
+			Assert.AreEqual(0.75f, e.Evaluate(new[] { 0.5f, 0.25f }));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A caller cannot change the sources an expression was compiled against")]
+		public void The_source_list_cannot_be_changed_from_outside()
+		{
+			// The compiled tree reads slots by position. Letting the list be edited would leave the two
+			// disagreeing, and every value after that would come from the wrong control.
+			var e = Parse("=a1+a2");
+			try
+			{
+				e.References.Clear();
+				Assert.Fail("The source list was changed from outside the expression.");
+			}
+			catch (NotSupportedException)
+			{
+			}
+			Assert.AreEqual(2, e.References.Count);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Limits written the wrong way round hold a value, never pin it to one number")]
+		public void Clamp_with_reversed_limits_still_holds_the_value()
+		{
+			// Written the wrong way round this used to return the same number for every input, so a
+			// control appeared dead while the expression looked correct.
+			Assert.AreEqual(0.5f, Value("=clamp(a1,1,0)", 0.5f));
+			Assert.AreEqual(0.5f, Value("=clamp(a1,0,1)", 0.5f));
+			Assert.AreEqual(1f, Value("=clamp(a1,1,0)", 5f));
+			Assert.AreEqual(0f, Value("=clamp(a1,1,0)", -5f));
+			// Two different inputs must not produce the same output.
+			Assert.AreNotEqual(Value("=clamp(a1,1,0)", 0.2f), Value("=clamp(a1,1,0)", 0.8f));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A function name is followed by its bracket, with nothing in between")]
+		public void A_space_before_the_bracket_is_not_a_function_call()
+		{
+			Refuses("=abs (1)");
+			Refuses("=min (1,2)");
+			Assert.AreEqual(1f, Value("=abs(1)"), "The ordinary spelling must still work.");
+			// Space elsewhere is still fine, because it separates rather than joins.
+			Assert.AreEqual(3f, Value("=1 + 2"));
+			Assert.AreEqual(2f, Value("=abs( 0 - 2 )"));
+		}
+
+		#endregion
+
+		#region Refusals
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Text that is not a complete expression is refused, with a reason")]
+		public void Incomplete_expressions_are_refused()
+		{
+			Refuses("=");
+			Refuses("=1+");
+			Refuses("=*2");
+			Refuses("=1++2");
+			Refuses("=(1");
+			Refuses("=1)");
+			Refuses("=a1 a2");
+			Refuses("=min(1)");
+			Refuses("=min(1,2,3)");
+			Refuses("=nope(1)");
+			Refuses("=z1");
+			Refuses("=a0");
+			Refuses("=a");
+			Refuses("=1..2");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A refusal says where the trouble is, and points at the right place")]
+		public void A_refusal_points_at_the_place_that_is_wrong()
+		{
+			// The position is shown to a person editing the field. Pointing at the wrong character is
+			// worse than pointing nowhere, because they will look there and find nothing wrong.
+			At("=a1&a2", 3, "the character that has no meaning");
+			At("=1+2)", 4, "the closing bracket that has no opening one");
+			// An unfinished bracket points at the bracket still waiting, not at the end of the text.
+			At("=abs(1+2", 4, "the bracket that was never closed");
+			At("=((1)", 1, "the outer bracket that was never closed");
+		}
+
+		private static void At(string text, int expected, string what)
+		{
+			MapExpression result;
+			string error;
+			int position;
+			Assert.IsFalse(MapExpression.TryParse(text, out result, out error, out position),
+				string.Format("'{0}' was accepted.", text));
+			Assert.AreEqual(expected, position,
+				string.Format("'{0}' should point at {1} (position {2}), not {3}.", text, what, expected, position));
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A plain mapping value is not treated as an expression")]
+		public void A_plain_mapping_value_is_not_an_expression()
+		{
+			Assert.IsFalse(MapExpression.IsExpression("a1"));
+			Assert.IsFalse(MapExpression.IsExpression("3"));
+			Assert.IsFalse(MapExpression.IsExpression(""));
+			Assert.IsFalse(MapExpression.IsExpression(null));
+			Assert.IsTrue(MapExpression.IsExpression("=a1*2"));
+		}
+
+		#endregion
+
+		#region Hostile input
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Nothing in the grammar can name a type, reach a member, or call anything of its own")]
+		public void Attempts_to_reach_outside_arithmetic_are_refused()
+		{
+			// Every one of these was accepted by at least one published expression library.
+			Refuses("=a.b");
+			Refuses("=1.GetType()");
+			Refuses("=\"a\".GetType()");
+			Refuses("=a1.GetType().Assembly");
+			Refuses("=System.Environment.Exit(0)");
+			Refuses("=System.Diagnostics.Process.Start('calc')");
+			Refuses("=System.IO.File.WriteAllText('x','y')");
+			Refuses("=typeof(int)");
+			Refuses("=new System.Object()");
+			Refuses("=Activator.CreateInstance(1)");
+			Refuses("=a1[0]");
+			Refuses("=a1{0}");
+			Refuses("=a1;a2");
+			Refuses("=a1=2");
+			Refuses("=a1=>a2");
+			Refuses("=$a1");
+			Refuses("=@a1");
+			Refuses("=#a1");
+			Refuses("=a1|a2");
+			Refuses("=a1&a2");
+			Refuses("=a1?a2:0");
+			Refuses("=`a1`");
+			Refuses("=a1\\a2");
+			Refuses("='abs'(1)");
+			Refuses("=${a1}");
+			Refuses("=a1//comment");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A function name spelled with lookalike letters is not the function")]
+		public void Lookalike_letters_do_not_match_a_function()
+		{
+			// Cyrillic a and e. A tokenizer that accepts any Unicode letter would match these.
+			Refuses("=аbs(1)");
+			Refuses("=а1*2");
+			Refuses("=abs (1)");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("An oversized or deeply nested expression is refused, never left to end the process")]
+		public void Oversized_expressions_are_refused_before_they_are_parsed()
+		{
+			// A stack overflow cannot be caught. If any of these were parsed instead of refused, this
+			// test would not fail: the whole test run would disappear without a message.
+			Refuses("=" + new string('(', 5000) + "1" + new string(')', 5000));
+			Refuses("=" + new string('-', 5000) + "1");
+			Refuses("=" + string.Join("+", new string[2000]).Replace("+", "1+") + "1");
+			Refuses("=" + new string('a', 1000));
+			var deep = "=1";
+			for (int i = 0; i < 40; i++)
+				deep = "=abs(" + deep.Substring(1) + ")";
+			Refuses(deep);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The depth cap counts every way of nesting, not only brackets")]
+		public void The_depth_cap_covers_nesting_without_brackets()
+		{
+			// Brackets are not the only thing that recurses. A run of minus signs descends once per sign
+			// and opens no bracket at all, and that shape is what was measured killing another parser.
+			// Relying on the length cap to bound it would tie two limits together silently: raising the
+			// length would reintroduce the crash with nothing to say so.
+			Refuses("=" + new string('-', MapExpression.MaxDepth + 1) + "1");
+			// While a mapping is stored in sixteen characters the length refuses a deep expression
+			// before the depth can. Both caps are real and both are kept; the tighter one speaks
+			// first. This says which, so that widening the column cannot quietly remove the guard.
+			var deepest = "=" + new string('-', MapExpression.MaxDepth - 1) + "1";
+			if (deepest.Length > MapExpression.MaxLength)
+				Assert.IsTrue(MapExpression.MaxDepth + 2 > MapExpression.MaxLength,
+					"Depth is reachable again; go back to checking one under the cap parses.");
+			else
+				Assert.AreEqual(-1f, Value(deepest),
+					"One sign inside the cap should still work.");
+			// Nesting through function calls descends the same way.
+			var nested = "1";
+			for (int i = 0; i < MapExpression.MaxDepth + 1; i++)
+				nested = "abs(" + nested + ")";
+			Refuses("=" + nested);
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The limits are the documented ones, and sit just under what is refused")]
+		public void The_limits_are_where_they_are_documented_to_be()
+		{
+			// Named outright. Deriving every case from the constants means the test passes for any
+			// value of them, including a cap so large it protects nothing.
+			Assert.AreEqual(16, MapExpression.MaxLength, "The length cap moved; say so deliberately.");
+			Assert.AreEqual(16, MapExpression.MaxDepth, "The nesting cap moved; say so deliberately.");
+			Assert.AreEqual(128, MapExpression.MaxNodes, "The node cap moved; say so deliberately.");
+			Assert.AreEqual(8, MapExpression.MaxReferences, "The source cap moved; say so deliberately.");
+			// Fixed text, so removing a cap fails here rather than quietly widening the test with it.
+			Refuses("=" + new string('(', 17) + "1" + new string(')', 17));
+			Refuses("=" + new string('1', 16));
+			// Nine sources need more room than a mapping is stored in, so the length refuses this
+			// before the source count can. Both caps are real; the tighter one simply speaks first.
+			Refuses("=a1+a2+a3+a4+a5+a6+a7+a8+a9");
+			Assert.IsTrue("=a1+a2+a3+a4+a5+a6+a7+a8+a9".Length > MapExpression.MaxLength,
+				"If this ever fits, the source cap must be the one refusing it.");
+			// Depth: one under the cap parses, one over does not. Both are only askable while the
+			// deeper of the two fits in what a mapping is stored in; below that the length refuses
+			// first. Which cap is doing the work is stated, so widening the column cannot quietly
+			// leave the depth guard untested.
+			var atCap = "=" + new string('(', MapExpression.MaxDepth) + "1" + new string(')', MapExpression.MaxDepth);
+			if (atCap.Length <= MapExpression.MaxLength)
+				Assert.IsNotNull(Parse(atCap));
+			else
+				Assert.IsTrue(MapExpression.MaxDepth * 2 + 2 > MapExpression.MaxLength,
+					"Depth is reachable again; go back to checking one under the cap parses.");
+			Refuses("=" + new string('(', MapExpression.MaxDepth + 1) + "1" + new string(')', MapExpression.MaxDepth + 1));
+			// Length: exactly at the cap parses, one over does not.
+			Refuses("=" + new string('1', MapExpression.MaxLength));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Nothing is compiled until every check has passed")]
+		public void Refused_text_never_reaches_the_compiler()
+		{
+			// Compilation is the only expensive and irreversible step. A refusal must cost far less
+			// than an acceptance, which it cannot if the text was compiled before being judged.
+			var hostile = new[]
+			{
+				"=System.Diagnostics.Process.Start('calc')",
+				"=" + new string('(', 5000) + "1" + new string(')', 5000),
+				"=a1[0]",
+				"=nope(1)",
+			};
+			var refusing = Stopwatch.StartNew();
+			for (int i = 0; i < 200; i++)
+				foreach (var text in hostile)
+				{
+					MapExpression r; string e; int p;
+					Assert.IsFalse(MapExpression.TryParse(text, out r, out e, out p));
+				}
+			refusing.Stop();
+			var accepting = Stopwatch.StartNew();
+			for (int i = 0; i < 200; i++)
+			{
+				MapExpression r; string e; int p;
+				Assert.IsTrue(MapExpression.TryParse("=a1*abs(a1)", out r, out e, out p));
+			}
+			accepting.Stop();
+			Assert.IsTrue(refusing.ElapsedMilliseconds < accepting.ElapsedMilliseconds,
+				string.Format("Refusing {0} hostile values took {1} ms, longer than compiling {2} good ones ({3} ms), so text is reaching the compiler before it is judged.",
+					hostile.Length * 200, refusing.ElapsedMilliseconds, 200, accepting.ElapsedMilliseconds));
+		}
+
+		#endregion
+
+		#region Cost
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Evaluating allocates nothing, so polling adds no work for the collector")]
+		public void Evaluating_allocates_nothing()
+		{
+			// Without optimisation the compiler keeps locals rooted and this measurement means nothing.
+			var debuggable = (DebuggableAttribute)Attribute.GetCustomAttribute(
+				typeof(MapExpressionTest).Assembly, typeof(DebuggableAttribute));
+			Assert.IsFalse(debuggable != null && debuggable.IsJITOptimizerDisabled,
+				"Allocation cannot be measured in an unoptimised build.");
+
+			AppDomain.MonitoringIsEnabled = true;
+			var e = Parse("=a1*abs(a1)");
+			var values = new[] { 0.5f, 0.25f };
+			for (int i = 0; i < 10000; i++) e.Evaluate(values);   // warm up and settle one-time costs
+
+			var before = AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+			for (int i = 0; i < 200000; i++) e.Evaluate(values);
+			var perEvaluation = (AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize - before) / 200000.0;
+
+			// Proof the instrument can see allocation at all, so a zero above means zero and not a
+			// measurement that never worked.
+			var control = AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+			object sink = null;
+			for (int i = 0; i < 200000; i++) sink = (object)(float)i;
+			GC.KeepAlive(sink);
+			var controlPer = (AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize - control) / 200000.0;
+
+			Assert.IsTrue(controlPer > 1.0,
+				string.Format("The allocation measurement is not working: boxing 200,000 values recorded {0:F3} bytes each.", controlPer));
+			// A single small object per evaluation is the smallest fault worth catching, so prove the
+			// measurement resolves one before trusting a zero.
+			var smallest = AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+			object one = null;
+			for (int i = 0; i < 200000; i++) one = new object();
+			GC.KeepAlive(one);
+			var smallestPer = (AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize - smallest) / 200000.0;
+			Assert.IsTrue(smallestPer > 1.0,
+				string.Format("The measurement cannot resolve one small object per call: {0:F3} bytes.", smallestPer));
+			Assert.IsTrue(perEvaluation < 1.0,
+				string.Format("Evaluation allocated {0:F3} bytes each, so it is doing work the polling loop should not.", perEvaluation));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("stress")]
+		[Description("A compiled expression is released once nothing refers to it")]
+		public void A_compiled_expression_is_released_when_dropped()
+		{
+			var reference = MakeCollectable();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			Assert.IsFalse(reference.IsAlive,
+				"A compiled expression stayed alive after nothing referred to it, so a device that reconnects repeatedly would grow.");
+		}
+
+		// Built in its own frame that returns only the weak reference, because a local in the calling
+		// frame keeps the object alive for the whole method and the result would mean nothing.
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static WeakReference MakeCollectable()
+		{
+			return new WeakReference(Parse("=a1*abs(a1)"));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("stress")]
+		[Description("Reports the cost of parsing and of evaluating, without asserting a speed")]
+		public void Reports_what_parsing_and_evaluating_cost()
+		{
+			// Timing is never asserted: it encodes the speed of whichever machine happens to run it.
+			// These numbers are recorded so a later change that makes evaluation expensive is visible.
+			var e = Parse("=a1*abs(a1)");
+			var values = new[] { 0.5f };
+			for (int i = 0; i < 10000; i++) e.Evaluate(values);
+
+			const int Runs = 2000000;
+			var evaluating = Stopwatch.StartNew();
+			for (int i = 0; i < Runs; i++) e.Evaluate(values);
+			evaluating.Stop();
+
+			const int Parses = 200;
+			var parsing = Stopwatch.StartNew();
+			for (int i = 0; i < Parses; i++)
+			{
+				MapExpression r; string err; int p;
+				MapExpression.TryParse("=a1*abs(a1)+clamp(a2,0,1)", out r, out err, out p);
+			}
+			parsing.Stop();
+
+			Console.WriteLine("evaluate : {0:F2} ns each, {1:N0} per second",
+				evaluating.Elapsed.TotalMilliseconds * 1000000.0 / Runs,
+				Runs / evaluating.Elapsed.TotalSeconds);
+			Console.WriteLine("parse    : {0:F3} ms each",
+				parsing.Elapsed.TotalMilliseconds / Parses);
+			Console.WriteLine("at 1000 Hz with 24 mappings: {0:F3} ms of each second",
+				24000.0 * evaluating.Elapsed.TotalMilliseconds / Runs);
+
+			// Timing is deliberately not asserted, but a test with no assertion at all cannot fail
+			// and so reads as coverage it does not provide. What is asserted is that two million
+			// repetitions still answer correctly, which a caching or state fault would break.
+			Assert.AreEqual(0.25f, e.Evaluate(values), "The answer changed while being repeated.");
+			Assert.AreEqual(0.25f, Parse("=a1*abs(a1)").Evaluate(values),
+				"A freshly parsed copy disagreed with one that had been run two million times.");
+		}
+
+		#endregion
+
+	}
+}

--- a/Tests/Common/MapExpressionUnitsTest.cs
+++ b/Tests/Common/MapExpressionUnitsTest.cs
@@ -1,0 +1,388 @@
+﻿// @under-test: Engine/Common/MapExpressionUnits.cs, Engine/Maps/Map.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpDX.XInput;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// A formula is written in plain units and has to reach the controller in the device's own.
+	/// These tests cover both ends of that translation, and that a stored formula is picked up at all.
+	/// </summary>
+	/// <remarks>
+	/// The gap these close is the one a person meets first: a formula typed into a row that then does
+	/// nothing, because nothing between the box and the controller ever looked at it.
+	/// </remarks>
+	[TestClass]
+	public class MapExpressionUnitsTest
+	{
+
+		/// <summary>A controller reporting nothing but one axis at the value given.</summary>
+		private static CustomDiState StateWithAxis(int index, int raw)
+		{
+			var state = Resting();
+			state.Axis[index - 1] = raw;
+			return state;
+		}
+
+		/// <summary>A controller nobody is touching.</summary>
+		private static CustomDiState Resting()
+		{
+			// Built from an empty DirectInput state, which is how the program itself makes one.
+			return new CustomDiState(new SharpDX.DirectInput.JoystickState());
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A row holding a formula is recognised as one, not read as a control name")]
+		public void A_row_holding_a_formula_is_recognised()
+		{
+			var map = new Map(MapCode.RightTrigger, "=a5*2", TargetType.RightTrigger, "", "", "");
+			Assert.IsNotNull(map.Expression, "The formula was not picked up, so the row does nothing.");
+			Assert.AreEqual(0, map.Index, "A formula names no single control, so there is no index.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A row mapped to one control is still read the old way")]
+		public void A_row_mapped_to_one_control_is_unchanged()
+		{
+			var map = new Map(MapCode.RightTrigger, "a5", TargetType.RightTrigger, "", "", "");
+			Assert.IsNull(map.Expression, "A plain mapping was mistaken for a formula.");
+			Assert.AreEqual(5, map.Index);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("An axis is read as -1 to 1 with the resting position at nought")]
+		public void An_axis_reads_as_minus_one_to_one()
+		{
+			var reference = new MapReference('a', 5);
+			Assert.AreEqual(0f, MapExpressionUnits.Read(reference, StateWithAxis(5, 32767), true), 0.001f,
+				"A stick nobody is touching has to read as nought.");
+			Assert.AreEqual(1f, MapExpressionUnits.Read(reference, StateWithAxis(5, 65535), true), 0.001f);
+			Assert.AreEqual(-1f, MapExpressionUnits.Read(reference, StateWithAxis(5, 0), true), 0.001f);
+			Assert.AreEqual(0.5f, MapExpressionUnits.Read(reference, StateWithAxis(5, 49151), true), 0.01f);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A control the device does not have reads as nought instead of failing")]
+		public void A_control_that_is_not_there_reads_as_nothing()
+		{
+			// A formula naming axis ninety on a device with four is describing something that is not
+			// there, and something that is not there is not being moved.
+			Assert.AreEqual(0f, MapExpressionUnits.Read(new MapReference('a', 90), Resting(), true));
+			Assert.AreEqual(0f, MapExpressionUnits.Read(new MapReference('b', 999), Resting(), true));
+			Assert.AreEqual(0f, MapExpressionUnits.Read(new MapReference('a', 1), null, true));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("=a5*2 on a trigger drives it, and reaches full travel at half a press")]
+		public void The_formula_that_was_reported_broken_now_drives_a_trigger()
+		{
+			// This is the case that was reported doing nothing at all.
+			var map = new Map(MapCode.RightTrigger, "=a5*2", TargetType.RightTrigger, "", "", "");
+			var values = new float[MapExpression.MaxReferences];
+
+			// Resting. A trigger rests at one end, which is nought, not the middle.
+			Assert.IsTrue(MapExpressionUnits.TryFill(map.Expression, StateWithAxis(5, 0), values, false));
+			Assert.AreEqual(0, MapExpressionUnits.ToTrigger(map.Expression.Evaluate(values)),
+				"A trigger nobody is touching has to stay at nought.");
+
+			// A quarter of the way: 0.25 doubled is 0.5, which is half a trigger.
+			Assert.IsTrue(MapExpressionUnits.TryFill(map.Expression, StateWithAxis(5, 16384), values, false));
+			var half = MapExpressionUnits.ToTrigger(map.Expression.Evaluate(values));
+			Assert.IsTrue(half > 120 && half < 136, "Expected about half travel, got " + half + ".");
+
+			// Half way: 0.5 doubled is 1, so the trigger is already fully pressed.
+			Assert.IsTrue(MapExpressionUnits.TryFill(map.Expression, StateWithAxis(5, 32767), values, false));
+			Assert.AreEqual(byte.MaxValue, MapExpressionUnits.ToTrigger(map.Expression.Evaluate(values)),
+				"Doubling means full travel is reached at half a press.");
+
+			// All the way up: doubled is 2, which cannot go past the end.
+			Assert.IsTrue(MapExpressionUnits.TryFill(map.Expression, StateWithAxis(5, 65535), values, false));
+			Assert.AreEqual(byte.MaxValue, MapExpressionUnits.ToTrigger(map.Expression.Evaluate(values)));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A formula's answer lands correctly on a stick, both ways from the middle")]
+		public void An_answer_lands_correctly_on_a_stick()
+		{
+			Assert.AreEqual(0, MapExpressionUnits.ToThumb(0f));
+			Assert.AreEqual(short.MaxValue, MapExpressionUnits.ToThumb(1f));
+			Assert.AreEqual(short.MinValue, MapExpressionUnits.ToThumb(-1f));
+			Assert.AreEqual(short.MaxValue, MapExpressionUnits.ToThumb(9f), "Cannot travel past the end.");
+			Assert.AreEqual(short.MinValue, MapExpressionUnits.ToThumb(-9f));
+			Assert.AreEqual(0, MapExpressionUnits.ToThumb(float.NaN), "Not a number has to rest, not jump.");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A negative answer still presses a trigger, which only travels one way")]
+		public void A_negative_answer_still_presses_a_trigger()
+		{
+			// A formula written for a stick put on a trigger should do something sensible rather than
+			// nothing at all.
+			Assert.AreEqual(byte.MaxValue, MapExpressionUnits.ToTrigger(-1f));
+			Assert.AreEqual(0, MapExpressionUnits.ToTrigger(0f));
+			Assert.AreEqual(0, MapExpressionUnits.ToTrigger(float.NaN));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Saving a row keeps the formula that was typed, rather than throwing it away")]
+		public void Saving_keeps_the_formula_that_was_typed()
+		{
+			// The reported symptom was a formula that did nothing. Part of that was here: saving put
+			// the text through the translation that turns the name of one control into how it is
+			// stored. A formula is not the name of a control, so it came back as nothing and the row
+			// quietly reverted to whatever it held before. The person is told nothing either way.
+			var box = new System.Windows.Forms.ComboBox();
+			var item = new x360ce.App.SettingsMapItem
+			{
+				IniSection = "PAD1",
+				IniKey = SettingName.RightTrigger,
+				Control = box,
+				Code = MapCode.RightTrigger,
+			};
+			var settings = x360ce.App.SettingsManager.Current.SettingsMap;
+			settings.Add(item);
+			try
+			{
+				box.Text = "=a5*2";
+				Assert.AreEqual("=a5*2", x360ce.App.SettingsManager.Current.GetSettingValue(box),
+					"The formula was not stored as typed, so the row loses it on save.");
+				// A row mapped to one control still stores the short form it always did.
+				box.Text = "Axis 5";
+				Assert.AreEqual("a5", x360ce.App.SettingsManager.Current.GetSettingValue(box),
+					"An ordinary mapping must still be stored the way it always was.");
+			}
+			finally
+			{
+				settings.Remove(item);
+				box.Dispose();
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Loading a stored formula shows it, with or without the switch being ready")]
+		public void Loading_a_stored_formula_shows_it()
+		{
+			// The switch is attached when a row is built, and settings are loaded into rows at a
+			// different moment. Making the display depend on the switch already existing meant that on
+			// the wrong ordering the formula was handed back to the code that reads a control name,
+			// which turns it into nothing. What the person then sees is an empty row.
+			var box = new System.Windows.Forms.ComboBox();
+			try
+			{
+				Assert.IsTrue(x360ce.App.Controls.MapExpressionToggle.ShowExpression(box, "=a5*2"),
+					"A stored formula was not shown, so the row appears empty and is lost on next save.");
+				Assert.AreEqual("=a5*2", box.Text);
+				Assert.AreEqual(System.Windows.Forms.ComboBoxStyle.DropDown, box.DropDownStyle,
+					"A row holding a formula has to be typeable, not a fixed list.");
+				// An ordinary mapping is left for the normal path to handle.
+				Assert.IsFalse(x360ce.App.Controls.MapExpressionToggle.ShowExpression(box, "a5"));
+			}
+			finally { box.Dispose(); }
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Each fx switch is named after its own row, so it can be found and pressed")]
+		public void Each_switch_is_named_after_its_row()
+		{
+			// Thirty switches sharing one name identify none of them, and a switch with no name of its
+			// own is reported by its window handle, which is a different number every run. Either way
+			// nothing can ask for the same switch twice: not a test, not a screen reader, not somebody
+			// driving the window from the keyboard.
+			var toggle = new x360ce.App.Controls.MapExpressionToggle();
+			try
+			{
+				toggle.NameAfterRow("Right Trigger");
+				Assert.AreEqual("RightTriggerExpressionToggle", toggle.Name,
+					"Windows reports this as the automation identifier. Empty means the window handle.");
+				Assert.AreEqual("Right Trigger formula", toggle.Text,
+					"Windows reports a button of this kind by its text and by nothing else, so the " +
+					"text is the only thing that can tell one switch from another.");
+				Assert.AreEqual("Right Trigger formula", toggle.AccessibleName,
+					"This is what a screen reader says.");
+				Assert.AreEqual("fx", x360ce.App.Controls.MapExpressionToggle.Label,
+					"The face stays the same two letters on every row.");
+				Assert.IsFalse(string.IsNullOrEmpty(toggle.AccessibleDescription),
+					"The name says which row; the description has to say what pressing it does.");
+				Assert.AreEqual(System.Windows.Forms.AccessibleRole.CheckButton, toggle.AccessibleRole);
+			}
+			finally { toggle.Dispose(); }
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A row's name is read as the words shown on screen")]
+		public void A_rows_name_reads_as_the_words_on_screen()
+		{
+			var box = new System.Windows.Forms.ComboBox { Name = "RightTriggerComboBox" };
+			try
+			{
+				Assert.AreEqual("Right Trigger", x360ce.App.Controls.MapExpressionToggle.RowNameFor(box));
+				box.AccessibleName = "Left Thumb Axis Y";
+				Assert.AreEqual("Left Thumb Axis Y", x360ce.App.Controls.MapExpressionToggle.RowNameFor(box),
+					"A name already written for a person is used as it stands.");
+			}
+			finally { box.Dispose(); }
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A formula that will not compile leaves the row doing nothing, not crashing")]
+		public void A_formula_that_will_not_compile_is_simply_not_a_mapping()
+		{
+			var map = new Map(MapCode.RightTrigger, "=a5*", TargetType.RightTrigger, "", "", "");
+			Assert.IsNull(map.Expression, "A broken formula must not become a live mapping.");
+			Assert.AreEqual(0, map.Index);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The clock is a source a formula can read, written as a word")]
+		public void The_clock_can_be_read()
+		{
+			MapExpression parsed;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse("=now", out parsed, out error, out position), error);
+			Assert.AreEqual(1, parsed.References.Count);
+			Assert.AreEqual(MapExpression.TimeType, parsed.References[0].Type);
+			// A formula that names it twice still reads one value, not two.
+			Assert.IsTrue(MapExpression.TryParse("=now+now", out parsed, out error, out position), error);
+			Assert.AreEqual(1, parsed.References.Count, "The clock is one source however often it is named.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The clock is fed like any other source, so a formula stays a plain calculation")]
+		public void The_clock_is_fed_like_any_other_source()
+		{
+			// Time arriving as a value rather than being read inside the formula is what keeps the
+			// whole thing testable: the same formula given the same instant always answers the same.
+			MapExpression parsed;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse("=now/60000", out parsed, out error, out position), error);
+			var values = new float[MapExpression.MaxReferences];
+			values[0] = 90000f;                      // a minute and a half
+			Assert.AreEqual(1.5f, parsed.Evaluate(values), 0.0001f);
+			values[0] = 0f;
+			Assert.AreEqual(0f, parsed.Evaluate(values), 0.0001f);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The clock counts minutes, which is what it is for")]
+		public void The_clock_can_be_read_as_minutes()
+		{
+			// Turning it on and off once a minute needs "round" and "floor" around it, which does not
+			// fit while a mapping is stored in sixteen characters. What does fit is the count itself,
+			// and that is what is checked until the column is widened.
+			// The fraction of the current minute, rounded, is on for the second half of every minute.
+			MapExpression parsed;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse("=now/60000", out parsed, out error, out position), error);
+			var values = new float[MapExpression.MaxReferences];
+			values[0] = 30000f;                      // half a minute
+			Assert.AreEqual(0.5f, parsed.Evaluate(values), 0.001f);
+			values[0] = 60000f;                      // one minute
+			Assert.AreEqual(1f, parsed.Evaluate(values), 0.001f);
+			values[0] = 150000f;                     // two and a half minutes
+			Assert.AreEqual(2.5f, parsed.Evaluate(values), 0.001f);
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The clock counts up, in milliseconds")]
+		public void The_clock_counts_up_in_milliseconds()
+		{
+			var first = MapExpressionUnits.Milliseconds();
+			System.Threading.Thread.Sleep(50);
+			var second = MapExpressionUnits.Milliseconds();
+			Assert.IsTrue(second > first, "The clock did not move.");
+			var moved = second - first;
+			Assert.IsTrue(moved >= 40f && moved < 2000f,
+				"Fifty milliseconds of waiting moved the clock by " + moved + ", which is not milliseconds.");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A source letter for the clock is still refused, so the word is the only spelling")]
+		public void The_clock_has_one_spelling()
+		{
+			MapExpression parsed;
+			string error;
+			int position;
+			Assert.IsFalse(MapExpression.TryParse("=t1", out parsed, out error, out position),
+				"'t1' must not quietly become the clock; a person who wants it writes 'now'.");
+		}
+
+		/// <summary>Works a formula out for a destination, the way the program does when polling.</summary>
+		private static float Drive(string formula, int axisIndex, int raw, bool isThumb)
+		{
+			MapExpression parsed;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse(formula, out parsed, out error, out position), error);
+			var values = new float[MapExpression.MaxReferences];
+			Assert.IsTrue(MapExpressionUnits.TryFill(parsed, StateWithAxis(axisIndex, raw), values, isThumb));
+			return parsed.Evaluate(values);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("=a5*2 on a trigger: rests at nothing and reaches full at a half press")]
+		public void The_reported_formula_gives_the_expected_trigger_values()
+		{
+			// A trigger rests at one end, not in the middle, and the whole of its travel is the
+			// whole of a trigger's travel. Reading it as though it rested in the middle put it at
+			// minus one while nobody was touching it, which doubled to minus two and came out as a
+			// trigger held fully down. That is what "not working properly" looked like.
+			Assert.AreEqual(0, MapExpressionUnits.ToTrigger(Drive("=a5*2", 5, 0, false)),
+				"Resting. Nobody is touching it.");
+			Assert.AreEqual(128, MapExpressionUnits.ToTrigger(Drive("=a5*2", 5, 16384, false)), 2,
+				"A quarter pressed, doubled, is half a trigger.");
+			Assert.AreEqual(255, MapExpressionUnits.ToTrigger(Drive("=a5*2", 5, 32767, false)),
+				"Half pressed, doubled, is a full trigger.");
+			Assert.AreEqual(255, MapExpressionUnits.ToTrigger(Drive("=a5*2", 5, 65535, false)),
+				"Fully pressed cannot go past the end.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A plain trigger mapping written as a formula changes nothing")]
+		public void A_plain_trigger_formula_matches_the_plain_mapping()
+		{
+			// Somebody switching a row to a formula and editing nothing must get exactly what they had.
+			Assert.AreEqual(0, MapExpressionUnits.ToTrigger(Drive("=a5", 5, 0, false)));
+			Assert.AreEqual(127, MapExpressionUnits.ToTrigger(Drive("=a5", 5, 32767, false)), 2);
+			Assert.AreEqual(255, MapExpressionUnits.ToTrigger(Drive("=a5", 5, 65535, false)));
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The same source on a stick still rests in the middle and goes both ways")]
+		public void The_same_source_on_a_stick_still_goes_both_ways()
+		{
+			// A stick rests in the middle, so the same reading has to mean something different here.
+			// This is the pair that stops one being fixed by breaking the other.
+			Assert.AreEqual(short.MinValue, MapExpressionUnits.ToThumb(Drive("=a1", 1, 0, true)),
+					"Pushed fully one way.");
+			Assert.AreEqual(0, MapExpressionUnits.ToThumb(Drive("=a1", 1, 32767, true)),
+					"Resting in the middle.");
+			Assert.AreEqual(short.MaxValue, MapExpressionUnits.ToThumb(Drive("=a1", 1, 65535, true)),
+					"Pushed fully the other way.");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A button reads the same whatever it drives")]
+		public void A_button_reads_the_same_either_way()
+		{
+			// Only an axis is read differently by its destination, because only an axis has a resting
+			// place that depends on what kind of control it is.
+			var pressed = Resting();
+			pressed.Buttons[0] = true;
+			var values = new float[MapExpression.MaxReferences];
+			MapExpression parsed;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse("=b1", out parsed, out error, out position), error);
+			Assert.IsTrue(MapExpressionUnits.TryFill(parsed, pressed, values, false));
+			Assert.AreEqual(1f, parsed.Evaluate(values), 0.001f);
+			Assert.IsTrue(MapExpressionUnits.TryFill(parsed, pressed, values, true));
+			Assert.AreEqual(1f, parsed.Evaluate(values), 0.001f);
+		}
+
+	}
+}

--- a/Tests/Common/MappingConversionTest.cs
+++ b/Tests/Common/MappingConversionTest.cs
@@ -1,0 +1,258 @@
+// @under-test: Engine/Common/ConvertHelper.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// Every mapped control passes through GetThumbValue on every poll, so it decides what a game
+	/// actually receives. It had no tests. These pin the behaviour a player can feel: the centre, the
+	/// ends, the dead zone, inversion, and the half ranges a wheel needs.
+	/// </summary>
+	/// <remarks>
+	/// DirectInput reports an axis as 0 to 65535 with 32768 at rest. A thumb stick answers -32768 to
+	/// 32767, a trigger 0 to 255. The numbers below are those ranges, not invented ones.
+	/// </remarks>
+	[TestClass]
+	public class MappingConversionTest
+	{
+
+		private const float DiMin = 0f;
+		private const float DiCentre = 32768f;
+		private const float DiMax = 65535f;
+
+		private static float Thumb(float diValue, float deadZone = 0f, float antiDeadZone = 0f,
+			float linear = 0f, bool inverted = false, bool half = false)
+		{
+			return ConvertHelper.GetThumbValue(diValue, deadZone, antiDeadZone, linear, inverted, half, true);
+		}
+
+		private static float Trigger(float diValue, float deadZone = 0f, float antiDeadZone = 0f,
+			float linear = 0f, bool inverted = false, bool half = false)
+		{
+			return ConvertHelper.GetThumbValue(diValue, deadZone, antiDeadZone, linear, inverted, half, false);
+		}
+
+		#region The ends and the middle
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A stick at rest reports the middle, and at its ends reports the ends")]
+		public void A_stick_maps_its_ends_and_its_middle()
+		{
+			// A stick that does not rest near zero is the most visible mapping fault there is: the
+			// character walks on its own.
+			Assert.AreEqual(-32768f, Thumb(DiMin), 1f, "Fully one way should reach the low end.");
+			Assert.AreEqual(32767f, Thumb(DiMax), 1f, "Fully the other way should reach the high end.");
+			Assert.AreEqual(0f, Thumb(DiCentre), 1f, "At rest a stick must sit at zero.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A trigger reports nothing when released and full when pressed")]
+		public void A_trigger_maps_its_ends()
+		{
+			Assert.AreEqual(0f, Trigger(DiMin), 1f, "A released trigger must report nothing.");
+			Assert.AreEqual(255f, Trigger(DiMax), 1f, "A pressed trigger must report full.");
+			Assert.AreEqual(128f, Trigger(DiCentre), 1f, "Half way should be about half.");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("The result never leaves the range the destination can carry")]
+		public void Results_stay_inside_the_destination_range()
+		{
+			// Sweeping the whole input range catches an off-by-one at either end, which reaches a game
+			// as a stick that cannot quite reach a corner.
+			for (var di = 0f; di <= DiMax; di += 257f)
+			{
+				var thumb = Thumb(di);
+				Assert.IsTrue(thumb >= -32768f && thumb <= 32767f,
+					string.Format("A stick left its range at {0}: {1}", di, thumb));
+				var trigger = Trigger(di);
+				Assert.IsTrue(trigger >= 0f && trigger <= 255f,
+					string.Format("A trigger left its range at {0}: {1}", di, trigger));
+			}
+		}
+
+		#endregion
+
+		#region Inversion
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Inverting a source swaps its ends and leaves the middle alone")]
+		public void Inverting_swaps_the_ends()
+		{
+			Assert.AreEqual(32767f, Thumb(DiMin, inverted: true), 1f);
+			Assert.AreEqual(-32768f, Thumb(DiMax, inverted: true), 1f);
+			Assert.AreEqual(0f, Thumb(DiCentre, inverted: true), 1f,
+				"Inverting must not move where a stick rests.");
+		}
+
+		#endregion
+
+		#region Dead zone
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Inside the dead zone a stick reports exactly nothing")]
+		public void Inside_the_dead_zone_a_stick_reports_nothing()
+		{
+			// Anything other than exactly zero here is drift, and drift is what a dead zone exists to
+			// remove.
+			const float deadZone = 4000f;
+			Assert.AreEqual(0f, Thumb(DiCentre, deadZone), 0f);
+			Assert.AreEqual(0f, Thumb(DiCentre + 1000f, deadZone), 0f);
+			Assert.AreEqual(0f, Thumb(DiCentre - 1000f, deadZone), 0f);
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Past the dead zone the full range is still reachable")]
+		public void Past_the_dead_zone_the_ends_are_still_reachable()
+		{
+			// A dead zone that also cost travel at the end would quietly make a controller weaker the
+			// more it was tuned.
+			const float deadZone = 4000f;
+			Assert.AreEqual(32767f, Thumb(DiMax, deadZone), 1f);
+			Assert.AreEqual(-32768f, Thumb(DiMin, deadZone), 1f);
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A dead zone does not make a stick jump when it is left")]
+		public void Leaving_the_dead_zone_does_not_jump()
+		{
+			// The value must grow from zero, not appear part way up, or a small movement produces a
+			// sudden lurch.
+			const float deadZone = 4000f;
+			var justOutside = Thumb(DiCentre + 4100f, deadZone);
+			Assert.IsTrue(justOutside > 0f && justOutside < 2000f,
+				string.Format("Leaving the dead zone jumped straight to {0}.", justOutside));
+		}
+
+		#endregion
+
+		#region Anti dead zone
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("An anti dead zone lifts the smallest movement above a game's own dead zone")]
+		public void An_anti_dead_zone_lifts_the_smallest_movement()
+		{
+			// This exists because some games apply a dead zone of their own that cannot be switched
+			// off. Without it the first part of a wheel's travel does nothing at all.
+			const float antiDeadZone = 8000f;
+			var small = Thumb(DiCentre + 100f, 0f, antiDeadZone);
+			Assert.IsTrue(small >= antiDeadZone,
+				string.Format("The smallest movement gave {0}, below the anti dead zone of {1}.", small, antiDeadZone));
+			Assert.AreEqual(32767f, Thumb(DiMax, 0f, antiDeadZone), 1f,
+				"An anti dead zone must not cost travel at the end.");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("At rest an anti dead zone still reports nothing")]
+		public void An_anti_dead_zone_leaves_the_resting_position_alone()
+		{
+			// Lifting the resting value would drive a game constantly with nobody touching anything.
+			Assert.AreEqual(0f, Thumb(DiCentre, 0f, 8000f), 1f);
+		}
+
+		#endregion
+
+		#region Sensitivity
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Sensitivity bends the response curve and never changes the ends")]
+		public void Sensitivity_bends_the_curve_but_not_the_ends()
+		{
+			// This is the setting the interface calls Sensitivity. It is worth pinning precisely
+			// because it does not multiply: it moves the middle of the travel while the ends stay
+			// where they are. That is why a player asking for twice the movement is not served by it,
+			// and why expressions were added.
+			var plain = Thumb(DiCentre + 8000f);
+			var bent = Thumb(DiCentre + 8000f, 0f, 0f, 50f);
+			Assert.AreNotEqual(plain, bent, "Sensitivity should change the middle of the travel.");
+			Assert.AreEqual(32767f, Thumb(DiMax, 0f, 0f, 50f), 1f, "The end must not move.");
+			Assert.AreEqual(0f, Thumb(DiCentre, 0f, 0f, 50f), 1f, "The resting position must not move.");
+			// A negative setting bends it the other way.
+			var bentBack = Thumb(DiCentre + 8000f, 0f, 0f, -50f);
+			Assert.AreNotEqual(bent, bentBack, "The sign should change which way the curve bends.");
+		}
+
+		#endregion
+
+		#region Half ranges
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Half of an axis fills a trigger, which is how combined pedals are separated")]
+		public void Half_an_axis_fills_a_trigger()
+		{
+			// A wheel that reports both pedals on one axis is separated this way, and it is the most
+			// common reason anybody reaches for a half range.
+			Assert.AreEqual(0f, Trigger(DiCentre, half: true), 1f, "The middle should be the start.");
+			Assert.AreEqual(255f, Trigger(DiMax, half: true), 1f, "The top should be full.");
+			// Everything below the middle belongs to the other pedal, so it stays at rest.
+			Assert.AreEqual(0f, Trigger(DiMin, half: true), 1f);
+			Assert.AreEqual(0f, Trigger(DiCentre - 10000f, half: true), 1f);
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A half range is ignored for a stick, which needs both directions")]
+		public void A_half_range_is_ignored_for_a_stick()
+		{
+			// A stick has to keep both halves, so asking for half of one must change nothing rather
+			// than quietly removing a direction.
+			Assert.AreEqual(Thumb(DiMin), Thumb(DiMin, half: true), 1f);
+			Assert.AreEqual(Thumb(DiMax), Thumb(DiMax, half: true), 1f);
+			Assert.AreEqual(Thumb(DiCentre), Thumb(DiCentre, half: true), 1f);
+		}
+
+		#endregion
+
+		#region Movement is orderly
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Pushing a stick further never sends the value backwards")]
+		public void Pushing_further_never_sends_the_value_backwards()
+		{
+			// A single step backwards anywhere in the travel is felt as a stutter, and it is the kind
+			// of fault that no single-value test would ever notice.
+			CheckRises(di => Thumb(di), "a stick");
+			CheckRises(di => Thumb(di, 4000f), "a stick with a dead zone");
+			CheckRises(di => Thumb(di, 0f, 8000f), "a stick with an anti dead zone");
+			CheckRises(di => Thumb(di, 4000f, 8000f, 50f), "a stick with everything set");
+			CheckRises(di => Trigger(di), "a trigger");
+			CheckRises(di => Trigger(di, 20f, 30f), "a trigger with dead zones");
+		}
+
+		private static void CheckRises(Func<float, float> map, string what)
+		{
+			var previous = map(0f);
+			for (var di = 64f; di <= DiMax; di += 64f)
+			{
+				var current = map(di);
+				Assert.IsTrue(current >= previous - 0.001f,
+					string.Format("{0} went backwards at {1}: {2} then {3}.", what, di, previous, current));
+				previous = current;
+			}
+		}
+
+		#endregion
+
+		#region Converting to what a game reads
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("A fraction becomes the whole number range a game reads")]
+		public void A_fraction_becomes_the_range_a_game_reads()
+		{
+			Assert.AreEqual(0, ConvertHelper.ConvertToShort(0f));
+			Assert.AreEqual(32767, ConvertHelper.ConvertToShort(1f));
+			Assert.AreEqual(-32768, ConvertHelper.ConvertToShort(-1f));
+			// This is the conversion an expression's result will pass through, so going past the end
+			// has to stay inside the range rather than wrapping to the opposite extreme.
+			Assert.IsTrue(ConvertHelper.ConvertToShort(2f) <= 32767,
+				"Going past the end must not wrap round to the other one.");
+			Assert.IsTrue(ConvertHelper.ConvertToShort(-2f) >= -32768,
+				"Going past the low end must not wrap round.");
+		}
+
+		#endregion
+
+	}
+}

--- a/Tests/Common/PadSettingsSchemaTest.cs
+++ b/Tests/Common/PadSettingsSchemaTest.cs
@@ -1,0 +1,117 @@
+// @under-test: Data/dbo/Tables/x360ce_PadSettings.sql, Engine/Data/x360ceModel.edmx, Engine/Common/MapExpression.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using x360ce.Engine;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// A mapping is written by the parser, described by the model, and kept in a column, and all three
+	/// have to agree about how long one may be. These tests are what makes them agree.
+	/// </summary>
+	/// <remarks>
+	/// The failure this prevents is silent. A parser cap larger than the column lets an expression pass
+	/// every check and then be cut short on the way to storage, so the person who wrote it is told
+	/// nothing and finds out later, in a game, through a control that no longer does what they set. A
+	/// model that still says sixteen fails at the same point for the same reason. Nothing at run time
+	/// notices any of this, so it has to be noticed here.
+	///
+	/// The backup schema under Change Scripts is deliberately not checked. It is written out from the
+	/// live database rather than read into it, so it cannot drift from a schema it is a copy of, and it
+	/// is not in the repository for a test to find.
+	/// </remarks>
+	[TestClass]
+	public class PadSettingsSchemaTest
+	{
+
+		/// <summary>
+		/// The columns that hold a mapping, taken from the parser's own side of the contract.
+		/// </summary>
+		/// <remarks>
+		/// Every value of <see cref="MapCode"/> names a column, and only those columns hold a mapping;
+		/// the rest of the table holds numbers. Listing them here by hand would be a fourth place to
+		/// keep in step, which is the very problem these tests exist to catch.
+		/// </remarks>
+		private static IEnumerable<string> MappingColumns()
+		{
+			return Enum.GetNames(typeof(MapCode)).Where(x => x != "None");
+		}
+
+		private static string Read(string relativePath)
+		{
+			var path = Path.Combine(Ui.RepoRoot.FullName, relativePath);
+			Assert.IsTrue(File.Exists(path), "Missing: " + relativePath);
+			return File.ReadAllText(path);
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The parser's length cap is the width of the column an expression is stored in")]
+		public void Length_cap_matches_the_column_it_is_stored_in()
+		{
+			var sql = Read("Data/dbo/Tables/x360ce_PadSettings.sql");
+			foreach (var column in MappingColumns())
+			{
+				var declaration = new Regex(@"\[" + column + @"\]\s+VARCHAR \((\d+)\)", RegexOptions.IgnoreCase);
+				var match = declaration.Match(sql);
+				Assert.IsTrue(match.Success, "No VARCHAR column named " + column + " in the table.");
+				Assert.AreEqual(MapExpression.MaxLength, int.Parse(match.Groups[1].Value),
+					"Column " + column + " and MapExpression.MaxLength disagree. An expression that " +
+					"passes validation would be cut short on its way into this column.");
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Both layers of the model describe the mapping columns at their real width")]
+		public void Model_describes_the_columns_at_their_real_width()
+		{
+			var model = XDocument.Parse(Read("Engine/Data/x360ceModel.edmx"));
+			// The storage layer names the table and the conceptual layer names the class. Both carry
+			// their own length, and either one being wrong fails the save.
+			foreach (var entityName in new[] { "x360ce_PadSettings", "PadSetting" })
+			{
+				var entity = model.Descendants()
+					.FirstOrDefault(x => x.Name.LocalName == "EntityType"
+						&& (string)x.Attribute("Name") == entityName);
+				Assert.IsNotNull(entity, "The model has no entity named " + entityName + ".");
+				foreach (var column in MappingColumns())
+				{
+					var property = entity.Elements()
+						.FirstOrDefault(x => x.Name.LocalName == "Property"
+							&& (string)x.Attribute("Name") == column);
+					Assert.IsNotNull(property, entityName + " has no property named " + column + ".");
+					var length = (string)property.Attribute("MaxLength");
+					Assert.AreEqual(MapExpression.MaxLength.ToString(), length,
+						entityName + "." + column + " is described as " + length + " characters, but the " +
+						"parser accepts " + MapExpression.MaxLength + ".");
+				}
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The busiest formula the application writes for itself fits in the column")]
+		public void The_formula_the_application_writes_fits_in_the_column()
+		{
+			// Switching a fully tuned row over to a formula writes this. If the longest thing the
+			// application produces on its own does not fit, the limit is wrong however consistent it is.
+			var seeded = MapExpressionSeed.FromSettings("a1",
+				deadZone: 8000f, antiDeadZone: 9830f, linear: 100f,
+				destinationMax: MapExpressionSeed.ThumbMax);
+			Assert.IsTrue(seeded.Length <= MapExpression.MaxLength,
+				"A row tuned in every way seeds a " + seeded.Length + " character formula, over the " +
+				MapExpression.MaxLength + " allowed: " + seeded);
+			// And it has to be an expression the parser will take back, not merely a short string.
+			MapExpression parsed;
+			string error;
+			int position;
+			Assert.IsTrue(MapExpression.TryParse(seeded, out parsed, out error, out position),
+				"The application seeded a formula it cannot itself read: " + error);
+		}
+
+	}
+}

--- a/Tests/Common/SettingsEventWiringTest.cs
+++ b/Tests/Common/SettingsEventWiringTest.cs
@@ -1,0 +1,137 @@
+﻿// @under-test: App.v4/Common/SettingsManager.Events.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Windows.Forms;
+using x360ce.App;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// Whether a mapping box that changes shape is still listened to.
+	/// </summary>
+	/// <remarks>
+	/// A mapping box is a list until it is switched to a formula, and a box that is typed into
+	/// afterwards. The two announce a change through different events, and which one the program
+	/// listens to is decided when it attaches, which happens once at startup while every box is
+	/// still a list.
+	///
+	/// So a box switched to a formula reported nothing at all. What the person typed stayed on
+	/// screen, looking applied, while the controller carried on doing whatever it did before, and
+	/// there was no way to adjust a formula and feel the difference.
+	/// </remarks>
+	[TestClass]
+	public class SettingsEventWiringTest
+	{
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A box that is typed into reports every keystroke")]
+		public void A_box_that_is_typed_into_reports_every_keystroke()
+		{
+			WithEventsRunning(manager =>
+			{
+				var box = new ComboBox { DropDownStyle = ComboBoxStyle.DropDown };
+				var reported = 0;
+				System.EventHandler<SettingChangedEventArgs> watch = (s, e) => reported++;
+				manager.SettingChanged += watch;
+				try
+				{
+					manager.RewireControl(box);
+					box.Text = "=a";
+					box.Text = "=a5";
+					box.Text = "=a5*4";
+					Assert.AreEqual(3, reported,
+						"A formula being typed has to reach the controller as it is written. " +
+						"Reported " + reported + " of 3 changes.");
+				}
+				finally
+				{
+					manager.SettingChanged -= watch;
+					box.Dispose();
+				}
+			});
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("A box that becomes a list again stops reporting its text")]
+		public void A_box_that_becomes_a_list_again_stops_reporting_its_text()
+		{
+			// Switching a formula off has to undo the change too, or a list would report a change
+			// every time the program wrote a value into it while loading.
+			WithEventsRunning(manager =>
+			{
+				var box = new ComboBox { DropDownStyle = ComboBoxStyle.DropDown };
+				var reported = 0;
+				System.EventHandler<SettingChangedEventArgs> watch = (s, e) => reported++;
+				manager.SettingChanged += watch;
+				try
+				{
+					manager.RewireControl(box);
+					box.DropDownStyle = ComboBoxStyle.DropDownList;
+					manager.RewireControl(box);
+					reported = 0;
+					box.Text = "";
+					Assert.AreEqual(0, reported, "A list should not report its text being written.");
+				}
+				finally
+				{
+					manager.SettingChanged -= watch;
+					box.Dispose();
+				}
+			});
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Asking twice does not make one keystroke count as two")]
+		public void Asking_twice_does_not_double_the_report()
+		{
+			// The switch can be pressed repeatedly, and loading asks as well. Attaching a second
+			// handler beside the first would save every keystroke twice.
+			WithEventsRunning(manager =>
+			{
+				var box = new ComboBox { DropDownStyle = ComboBoxStyle.DropDown };
+				var reported = 0;
+				System.EventHandler<SettingChangedEventArgs> watch = (s, e) => reported++;
+				manager.SettingChanged += watch;
+				try
+				{
+					manager.RewireControl(box);
+					manager.RewireControl(box);
+					manager.RewireControl(box);
+					box.Text = "=b1";
+					Assert.AreEqual(1, reported, "One keystroke was reported " + reported + " times.");
+				}
+				finally
+				{
+					manager.SettingChanged -= watch;
+					box.Dispose();
+				}
+			});
+		}
+
+		/// <summary>
+		/// Runs the body with the manager listening, and leaves it as it was found.
+		/// </summary>
+		/// <remarks>
+		/// The manager is a single shared object and starts with its events suspended, which is how
+		/// the program loads settings without every write counting as a change. A test which left it
+		/// listening would change what the next test sees.
+		/// </remarks>
+		private static void WithEventsRunning(System.Action<SettingsManager> body)
+		{
+			var manager = SettingsManager.Current;
+			var status = manager.NotifySettingsStatus;
+			manager.NotifySettingsStatus = count => { };
+			manager.ResumeEvents();
+			try
+			{
+				body(manager);
+			}
+			finally
+			{
+				manager.SuspendEvents();
+				manager.NotifySettingsStatus = status;
+			}
+		}
+
+	}
+}

--- a/Tests/Common/StaticEventReleaseTest.cs
+++ b/Tests/Common/StaticEventReleaseTest.cs
@@ -1,0 +1,68 @@
+﻿// @under-test: App.v4/MainForm.cs
+// @area: lifetime   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// A window which listens to a static event has to stop listening when it closes.
+	/// </summary>
+	/// <remarks>
+	/// A static event keeps its handlers for as long as the program runs, so a form which
+	/// subscribes and never unsubscribes stays reachable after its window is gone, and carries on
+	/// being called. The handler then reads controls which have already been disposed. A disposed
+	/// ToolStripComboBox answers null for its ComboBox, so that read fails outright rather than
+	/// quietly doing nothing, and the failure is reported from a place which says nothing about
+	/// the cause.
+	///
+	/// That is what happened. The main window listened for the game in front changing, which the
+	/// foreground watch keeps announcing while the program shuts down. The subscription is one
+	/// line and the release is one line, half a file apart, so it is checked here rather than left
+	/// to be noticed in review.
+	/// </remarks>
+	[TestClass]
+	public class StaticEventReleaseTest
+	{
+
+		[TestMethod, TestCategory("lifetime")]
+		[Description("Every static event the main window listens to is released again")]
+		public void The_main_window_releases_every_static_event_it_listens_to()
+		{
+			var path = Path.Combine(Ui.RepoRoot.FullName, "App.v4", "MainForm.cs");
+			Assert.IsTrue(File.Exists(path), path + " was not found.");
+			var text = File.ReadAllText(path);
+			var subscriptions = Handlers(text, "+=");
+			var releases = Handlers(text, "-=");
+			// Without this the test would pass by reading nothing at all, which is the one way it
+			// could go wrong without anybody noticing.
+			Assert.AreNotEqual(0, subscriptions.Count,
+				"No subscription to a static event was found in " + path +
+				", so this test is no longer reading what it was written to read.");
+			var unreleased = new List<string>();
+			foreach (var one in subscriptions)
+				if (!releases.Contains(one))
+					unreleased.Add(one);
+			Assert.AreEqual(0, unreleased.Count,
+				"The main window subscribes to " + string.Join(", ", unreleased.ToArray()) +
+				" and never lets go, so it is still called after its window has been disposed.");
+		}
+
+		/// <summary>Each "SettingsManager.{event} {sign} {handler}" written in the file.</summary>
+		/// <remarks>
+		/// Only events reached straight off the class are read. Anything behind an instance, such
+		/// as the options object, is released with that object and is not what this is about.
+		/// </remarks>
+		static HashSet<string> Handlers(string text, string sign)
+		{
+			var found = new HashSet<string>();
+			var rx = new Regex(@"SettingsManager\.(\w+)\s*" + Regex.Escape(sign) + @"\s*([\w.]+)\s*;");
+			foreach (Match m in rx.Matches(text))
+				found.Add(m.Groups[1].Value + " " + m.Groups[2].Value);
+			return found;
+		}
+
+	}
+}

--- a/Tests/Common/TestDeviceTest.cs
+++ b/Tests/Common/TestDeviceTest.cs
@@ -1,0 +1,148 @@
+// @under-test: App.v4/Common/TestDeviceHelper.cs
+// @area: mapping   @layer: unit
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpDX.DirectInput;
+using System;
+using System.Linq;
+using System.Threading;
+using x360ce.App;
+using x360ce.Engine;
+using x360ce.Engine.Data;
+
+namespace x360ce.Tests
+{
+	/// <summary>
+	/// The built-in test controller moves and presses in a fixed pattern, which is what lets mapping be
+	/// checked without a physical device in hand. These tests pin that pattern, because a test device
+	/// that quietly stopped behaving as described would make every test built on it worthless while
+	/// still reporting success.
+	/// </summary>
+	[TestClass]
+	public class TestDeviceTest
+	{
+
+		private static UserDevice NewDevice()
+		{
+			var device = TestDeviceHelper.NewUserDevice();
+			Assert.IsNotNull(device, "The test controller could not be created.");
+			return device;
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("The test controller offers the controls the mapping needs to exercise")]
+		public void The_test_controller_has_the_controls_it_claims()
+		{
+			var device = NewDevice();
+			Assert.AreEqual(5, device.CapAxeCount, "Axes are needed for both sticks and the triggers.");
+			Assert.AreEqual(10, device.CapButtonCount, "Buttons are needed for the face and shoulder controls.");
+			Assert.AreEqual(1, device.CapPovCount, "A hat switch is needed for the d-pad.");
+			Assert.AreEqual(TestDeviceHelper.ProductGuid, device.ProductGuid,
+				"It must be recognisable as the test controller, since real devices are read differently.");
+			Assert.IsTrue(device.IsEnabled, "It is useless to a test unless it starts enabled.");
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("Two test controllers do not share a name or an identity")]
+		public void Two_test_controllers_are_distinct()
+		{
+			// Mapping is stored against the instance, so two devices sharing one would overwrite each
+			// other's settings.
+			var first = NewDevice();
+			var second = NewDevice();
+			Assert.AreNotEqual(first.InstanceGuid, second.InstanceGuid);
+		}
+
+		[TestMethod, TestCategory("mapping")]
+		[Description("It reports the controls it says it has, so a mapping can find them")]
+		public void The_test_controller_describes_its_controls()
+		{
+			var objects = TestDeviceHelper.GetDeviceObjects();
+			Assert.IsNotNull(objects, "A device with no described controls cannot be mapped.");
+			Assert.IsTrue(objects.Length > 0, "The test controller described no controls at all.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Exactly one button is held at any moment, which is what makes the pattern readable")]
+		public void Exactly_one_button_is_held_at_a_time()
+		{
+			// The pattern walks one button at a time. If two were ever held together, a test could not
+			// tell which button a mapped output came from.
+			var device = NewDevice();
+			for (var sample = 0; sample < 25; sample++)
+			{
+				var state = TestDeviceHelper.GetCurrentState(device);
+				var held = state.Buttons.Take(device.CapButtonCount).Count(x => x);
+				Assert.AreEqual(1, held,
+					string.Format("{0} buttons were held at once; the pattern presses one at a time.", held));
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("Every value it reports is inside the range DirectInput allows")]
+		public void Every_reported_value_is_inside_the_directinput_range()
+		{
+			// A value outside the range would push the mapping past the end of a stick, and the fault
+			// would look like a mapping defect rather than a test device defect.
+			var device = NewDevice();
+			for (var sample = 0; sample < 25; sample++)
+			{
+				var state = TestDeviceHelper.GetCurrentState(device);
+				foreach (var axis in new[] { state.X, state.Y, state.Z, state.RotationX, state.RotationY, state.RotationZ })
+					Assert.IsTrue(axis >= 0 && axis <= 65535,
+						string.Format("An axis reported {0}, outside the range DirectInput allows.", axis));
+				foreach (var slider in state.Sliders)
+					Assert.IsTrue(slider >= 0 && slider <= 65535,
+						string.Format("A slider reported {0}, outside the range DirectInput allows.", slider));
+				foreach (var pov in state.PointOfViewControllers.Take(device.CapPovCount))
+					Assert.IsTrue(pov == -1 || (pov >= 0 && pov <= 36000),
+						string.Format("A hat switch reported {0}; it must be a hundredth of a degree or -1 for centred.", pov));
+				Thread.Sleep(1);
+			}
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("stress")]
+		[Description("The pattern moves, so a test that waits sees something change")]
+		public void The_pattern_actually_moves()
+		{
+			// A frozen test device would let every mapping test pass while proving nothing, which is
+			// the failure this test exists to catch.
+			var device = NewDevice();
+			var first = TestDeviceHelper.GetCurrentState(device);
+			var startedAt = DateTime.UtcNow;
+			var moved = false;
+			// The pattern completes a sweep in four seconds and then rests for two, so a little over
+			// one full cycle is enough to be certain rather than lucky.
+			while (!moved && (DateTime.UtcNow - startedAt).TotalSeconds < 7)
+			{
+				Thread.Sleep(50);
+				var now = TestDeviceHelper.GetCurrentState(device);
+				moved = now.X != first.X || now.Y != first.Y
+					|| now.PointOfViewControllers[0] != first.PointOfViewControllers[0]
+					|| !now.Buttons.Take(device.CapButtonCount)
+						.SequenceEqual(first.Buttons.Take(device.CapButtonCount));
+			}
+			Assert.IsTrue(moved, "Nothing on the test controller changed within a full cycle.");
+		}
+
+		[TestMethod, TestCategory("mapping"), TestCategory("critical")]
+		[Description("What the test controller reports maps to a usable value for a game")]
+		public void What_it_reports_maps_to_a_usable_value()
+		{
+			// This is the point of the whole device: its output goes through the same conversion a real
+			// controller's does, and has to arrive inside the range a game reads.
+			var device = NewDevice();
+			for (var sample = 0; sample < 20; sample++)
+			{
+				var state = TestDeviceHelper.GetCurrentState(device);
+				var stick = ConvertHelper.GetThumbValue(state.X, 0f, 0f, 0f, false, false, true);
+				Assert.IsTrue(stick >= -32768f && stick <= 32767f,
+					string.Format("A stick mapped to {0}, outside what a game can read.", stick));
+				var trigger = ConvertHelper.GetThumbValue(state.Y, 0f, 0f, 0f, false, false, false);
+				Assert.IsTrue(trigger >= 0f && trigger <= 255f,
+					string.Format("A trigger mapped to {0}, outside what a game can read.", trigger));
+				Thread.Sleep(1);
+			}
+		}
+
+	}
+}

--- a/Tests/Run-Tests.ps1
+++ b/Tests/Run-Tests.ps1
@@ -26,10 +26,11 @@ param(
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $PSScriptRoot
 
-# vswhere is asked first because it is the supported way to find an installation. It reports
-# nothing when the installer's instance record is missing, which happens after some upgrades
-# even though Visual Studio itself works, so the folders it would have pointed at are searched
-# directly rather than failing.
+# vswhere is asked first because it is the supported way to find an installation. It
+# reports nothing when the installer's instance record is missing, which happens after
+# some upgrades and after the package cache is cleaned, even though Visual Studio itself
+# works. The folders it would have pointed at are then searched directly rather than
+# failing on a machine which can build perfectly well.
 function Find-VsTool {
     param(
         [Parameter(Mandatory = $true)][string]$Pattern,

--- a/Tests/Run-Tests.ps1
+++ b/Tests/Run-Tests.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Build and run the x360ce test suite.
 .DESCRIPTION
@@ -26,13 +26,35 @@ param(
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $PSScriptRoot
 
-$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found. Visual Studio is required." }
+# vswhere is asked first because it is the supported way to find an installation. It reports
+# nothing when the installer's instance record is missing, which happens after some upgrades
+# even though Visual Studio itself works, so the folders it would have pointed at are searched
+# directly rather than failing.
+function Find-VsTool {
+    param(
+        [Parameter(Mandatory = $true)][string]$Pattern,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $found = & $vswhere -latest -prerelease -find $Pattern | Select-Object -First 1
+        if ($found) { return $found }
+    }
+    $roots = @(
+        "${env:ProgramFiles}\Microsoft Visual Studio",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio"
+    ) | Where-Object { Test-Path $_ }
+    # Newest edition first, so a side by side install picks the same one vswhere would, and
+    # the processor specific copies are left out because they are not what vswhere reports.
+    $found = Get-ChildItem -Path $roots -Filter (Split-Path -Leaf $Pattern) -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -notmatch 'amd64|arm64' } |
+        Sort-Object FullName -Descending | Select-Object -First 1
+    if (-not $found) { throw "$Name not found. Visual Studio is required." }
+    return $found.FullName
+}
 
-$msbuild = & $vswhere -latest -prerelease -find '**\Bin\MSBuild.exe' | Select-Object -First 1
-if (-not $msbuild) { throw "MSBuild.exe not found." }
-$vstest = & $vswhere -latest -prerelease -find '**\TestWindow\vstest.console.exe' | Select-Object -First 1
-if (-not $vstest) { throw "vstest.console.exe not found." }
+$msbuild = Find-VsTool -Pattern '**\Bin\MSBuild.exe' -Name 'MSBuild.exe'
+$vstest = Find-VsTool -Pattern '**\TestWindow\vstest.console.exe' -Name 'vstest.console.exe'
 
 $project = Join-Path $PSScriptRoot 'x360ce.Tests.csproj'
 & $msbuild $project -t:restore,build -p:Configuration=$Configuration -v:minimal -nologo

--- a/Tests/x360ce.Tests.csproj
+++ b/Tests/x360ce.Tests.csproj
@@ -36,6 +36,13 @@
 		<Reference Include="WindowsBase" />
 		<Reference Include="System.Windows.Forms" />
 		<Reference Include="System.Configuration" />
+		<!-- The test controller reports a DirectInput state, so the type has to resolve here too. -->
+		<Reference Include="SharpDX">
+			<HintPath>..\App.v4\Resources\SharpDX\SharpDX.dll</HintPath>
+		</Reference>
+		<Reference Include="SharpDX.DirectInput">
+			<HintPath>..\App.v4\Resources\SharpDX\SharpDX.DirectInput.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Closes #1616

Ten commits, 63 files, version 4.18.40.0.

## What this adds

A mapping row can hold a formula instead of a single control. Press the small `fx` button beside the row and type one, starting with `=`.

```
=a5*2        double the trigger, so it reaches full at a half press
=a1*0.5      halve the stick, for aiming through a scope
=a1*abs(a1)  fine control near the centre, full speed at the edge
=max(a1,0)   use only one half of a pedal axis
=b1          a button driving a trigger, all the way or not at all
```

Sources are written the way mappings are stored: `a1` is axis 1, `b2` is button 2, `s1` is slider 1. Everything inside a formula is a fraction of full travel, so the same formula means the right thing wherever it is put. The destination converts it back: a trigger counts to 255, a stick to 32767. `now` reads the milliseconds since the program started, so a row can repeat on a timer.

A formula replaces the dead zone, anti dead zone and sensitivity for its row rather than being layered on top. Switching a row over seeds it with the formula that reproduces those settings, so nothing changes until the person edits it, and they are shown their own tuning written in the new syntax.

The formula takes effect as it is typed. The `fx` button is green while it is understood and driving the row, red while it is written down and not, with the reason in the tooltip.

## What this fixes

| Fault | Cause |
|---|---|
| Controller picture grey, or moving on its own | The program assumed its virtual controller was given XInput slot 1. Windows chooses the slot; it now reads which one it got. |
| Leftover virtual controllers listed as real devices | They are recognised by their place in the device tree and left out of the list. The Issues tab reports them and removes them, elevating the same way every other administrative action does. |
| Choosing a mapping from the list could crash | One menu serves every box on a pad, and the click was handled after the box it belonged to had been cleared. The menu now carries its own target. 13 of the 30 crash reports from 4.18.23 users. |
| Crash while closing | The window listened to a static event and never let go, so it was still called after it was disposed. |
| Crash instead of reporting a missing bus driver | A failed library load carried on into the library anyway. |
| A whole processor core used while idle | The mapping list was rebuilt on every poll, a thousand times a second. |
| Installing the bus driver added another one each time | The installer now counts what is there first. |
| Build and release scripts refused to build | `vswhere` reports nothing when the installer's instance record is missing, even though Visual Studio works. The scripts now search the install folders as well. |

## Testing

177 tests, 176 passing. The one failure, `Generated_agent_file_matches_its_sources`, is pre-existing and unrelated to this branch.

New coverage on this branch:

- Formula parsing, evaluation, units, seeding, help and readme agreement, compatibility with the old mapping path.
- Cost and memory: the formula path is measured against the thousand-a-second poll, and compiled formulas are checked for being released rather than accumulating.
- Event wiring: a box that is typed into reports every keystroke, a box that becomes a list again stops, and asking twice does not save one keystroke twice.
- Static event release: the main window gives back every static event it takes.

Verified by hand in the running application: a saved formula loads, applies, and paints the `fx` button green; the trigger reads 0 and 255 for a button and 0 to 255 across an axis; a controller lands on whichever XInput slot Windows gives it and the picture follows it.

## Not in this change

A formula is limited to 16 characters, the width a mapping is stored in. The migration script that widens the column is written and not applied; the limit moves with it in a later release.

## Changelog this delivers

Version goes from 4.18.23.0 to 4.18.40.0. These are the entries added to `App.v4/Documents/ChangeLog.txt`.

```
v4.18.40.0 (2026-08-27)
- Fixed: A formula had no effect until the box was left.
- Added: The fx button turns green when the formula works and red when it does not.

v4.18.38.0 (2026-08-27)
- Fixed: Choosing a mapping from the list could crash the program.
- Fixed: Program could crash while closing, after its window had gone.
- Fixed: Program crashed instead of saying the virtual bus driver was missing.

v4.18.35.0 (2026-08-27)
- Added: A mapping row can hold a formula instead of a single control.
- Added: An fx button on each mapping row turns it into a formula.
- Added: Formulas can read the clock, in milliseconds since the program started.
- Added: Issues tab lists virtual controllers left behind by earlier runs and removes them.
- Fixed: Controller picture stayed grey, or moved while nothing was touched.
- Fixed: Virtual controllers left behind by earlier runs appeared as real devices and returned after every restart.
- Fixed: Removing leftover virtual controllers did nothing unless already running as Administrator.
- Fixed: Installing the virtual bus driver added another one each time.
- Fixed: Program used a whole processor core while doing nothing.
- Fixed: Devices tab buttons and the HID Guardian menu had no icons.
- Changed: Mapping rows can be reached by name by a screen reader.
- Known: A formula is limited to 16 characters, which is what a mapping is stored in.
```